### PR TITLE
Pick context name from the stream config

### DIFF
--- a/src/mod/endpoints/mod_aes67/aes67_api.h
+++ b/src/mod/endpoints/mod_aes67/aes67_api.h
@@ -12,6 +12,8 @@
 
 #define MAX_IO_CHANNELS 256
 
+#define TS_CONTEXT_NAME_LEN 100
+
 typedef enum
 { L16, L24 } aes67_codec_t;
 
@@ -40,6 +42,7 @@ typedef struct
   int rtp_payload_type;
   int rtp_jitbuf_latency;
   gboolean txdrop;
+  char *ts_context_name;
 } pipeline_data_t;
 
 struct g_stream

--- a/src/switch.c
+++ b/src/switch.c
@@ -757,12 +757,8 @@ int main(int argc, char *argv[])
 		}
 #endif
 		else if (!strcmp(local_argv[x], "-version")) {
-<<<<<<< HEAD
 			fprintf(stdout, "SIP Server version: %s (%s)\n", switch_version_full(), switch_version_revision_human());
-=======
-			fprintf(stdout, "FreeSWITCH version: %s (%s)\n", switch_version_full(), switch_version_revision_human());
 #if ENABLE_SENTRY
->>>>>>> 2d2c1a3188a20cbdd44d1749c7158abb09040b9c
 			sentry_shutdown();
 #endif
 			exit(EXIT_SUCCESS);


### PR DESCRIPTION
The threadshare pipeline elements share one or multiple threads based on the context name specified during their instantiation.
Exposing an option `ts-context-name` in the stream config will help to group streams into separate contexts. Default behavior is all streams running in the same context. This is applicable only if the ENABLE_THREAD is defined (true by default)