### PR TITLE
mod_aes67: overwrite the gstreamer path variables

### DIFF
--- a/src/include/switch_core.h
+++ b/src/include/switch_core.h
@@ -2908,6 +2908,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_start_text_thread(switch_cor
 
 SWITCH_DECLARE(const char *) switch_core_get_event_channel_key_separator(void);
 
+SWITCH_DECLARE(void) switch_setenv (const char *var, const char *value, int overwrite);
+
 SWITCH_END_EXTERN_C
 #endif
 /* For Emacs:


### PR DESCRIPTION
Consider the relative path ../../Media from the modules directory as the location of GStreamer installation path

Add <mod_dir>/../../Media/bin to the PATH(LD_LIBRARY_PATH) for the loader to pick gstreamer libs while loading the mod_aes67

Set <mod_dir>/../../Media as GST_PLUGIN_SYSTEM_PATH before gst_init so that that GStreamer will look for its plugins only in that directory