### PR TITLE
mod_aes67: use system env as fallback for GStreamer

### DIFF
--- a/src/mod/endpoints/mod_aes67/mod_aes67.c
+++ b/src/mod/endpoints/mod_aes67/mod_aes67.c
@@ -1675,8 +1675,8 @@ SWITCH_MODULE_LOAD_FUNCTION (mod_aes67_load)
 	if (realpath(media_dir, media_dir) !=  NULL) {
 #endif
 		switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Resolved the abolute path to Media (GStreamer) path as %s\n", media_dir);
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Setting it as environment variable: GST_PLUGIN_SYSTEM_PATH\n");
-    switch_setenv("GST_PLUGIN_SYSTEM_PATH", media_dir, TRUE);
+    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Setting it as environment variable: GST_PLUGIN_PATH\n");
+    switch_setenv("GST_PLUGIN_PATH", media_dir, TRUE);
 	} else {
 		switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to resolve the Media (GStreamer) path"
 #ifdef _WIN32


### PR DESCRIPTION
Use GST_PLUGIN_PATH instead of GST_PLUGIN_SYSTEM_PATH With this the plugins at GST_PLUGIN_PATH (i.e. mod_dir/../../Media/) get precedence if they exist, else the default system installed location is used as a fallback