### PR TITLE
mod_aes67: switch to ptp in the background and protect shared streams list from race condition

### DIFF
--- a/src/mod/endpoints/mod_aes67/aes67_api.c
+++ b/src/mod/endpoints/mod_aes67/aes67_api.c
@@ -643,9 +643,9 @@ error:
 void
 use_ptp_clock(g_stream_t *stream, GstClock *ptp_clock)
 {
+  g_atomic_int_set(&stream->clock_sync, 0);
+  gst_element_set_state(GST_ELEMENT (stream->pipeline), GST_STATE_PAUSED);
 
-  g_atomic_int_set (&stream->clock_sync, 0);
-  gst_element_set_state (GST_ELEMENT (stream->pipeline), GST_STATE_PAUSED);
   /* cb_rx_stats_id will be non zero only when
   Rx is operational and pipeline clock is not ptp*/
   if (stream->cb_rx_stats_id) {
@@ -658,13 +658,12 @@ use_ptp_clock(g_stream_t *stream, GstClock *ptp_clock)
     stream->clock = NULL;
   }
 
-  gst_pipeline_use_clock (GST_PIPELINE(stream->pipeline), ptp_clock);
-  gst_pipeline_set_clock (GST_PIPELINE(stream->pipeline), ptp_clock);
-  gst_element_set_state (GST_ELEMENT (stream->pipeline), GST_STATE_PLAYING);
+  gst_pipeline_use_clock(GST_PIPELINE(stream->pipeline), ptp_clock);
+  gst_pipeline_set_clock(GST_PIPELINE(stream->pipeline), ptp_clock);
+  gst_element_set_state(GST_ELEMENT (stream->pipeline), GST_STATE_PLAYING);
   dump_pipeline(stream->pipeline, "ptp-clock-switch");
 
   g_atomic_int_set (&stream->clock_sync, 1);
-
 }
 
 void *

--- a/src/mod/endpoints/mod_aes67/aes67_api.c
+++ b/src/mod/endpoints/mod_aes67/aes67_api.c
@@ -413,17 +413,12 @@ create_pipeline (pipeline_data_t *data, event_callback_t * error_cb)
           "media", G_TYPE_STRING, "audio", NULL);
     }
 
-#ifndef ENABLE_THREADSHARE
     rtpjitbuf = gst_element_factory_make("rtpjitterbuffer", "rx-jitbuf");
-#else
-    MAKE_TS_ELEMENT(rtpjitbuf, "ts-jitterbuffer", "rx-jitbuf", ts_ctx);
     g_signal_connect_data(rtpjitbuf, "request-pt-map", G_CALLBACK(request_pt_map),
         gst_caps_ref(udp_caps), destroy_caps, 0);
-#endif
+
     g_object_set(rtpjitbuf, "latency", data->rtp_jitbuf_latency,
-#ifndef ENABLE_THREADSHARE
         "mode", 0 /* none */,
-#endif
         NULL);
     rx_audioconv = gst_element_factory_make ("audioconvert", "rx-aconv");
     g_object_set(rx_audioconv, "dithering", 0 /* none */, NULL);

--- a/src/mod/endpoints/mod_aes67/aes67_api.h
+++ b/src/mod/endpoints/mod_aes67/aes67_api.h
@@ -76,5 +76,6 @@ gchar *get_rtp_stats (g_stream_t *stream);
 void drop_output_buffers (gboolean drop, g_stream_t * stream);
 gboolean add_appsink(g_stream_t *stream, guint ch_idx, gchar *session);
 gboolean remove_appsink(g_stream_t *stream, guint ch_idx, gchar *session);
+void use_ptp_clock(g_stream_t *stream, GstClock *ptp_clock);
 
 #endif /*__GSTREAMER_API__*/

--- a/src/mod/endpoints/mod_aes67/mod_aes67.c
+++ b/src/mod/endpoints/mod_aes67/mod_aes67.c
@@ -2501,8 +2501,6 @@ load_endpoints (switch_xml_t endpoints, switch_bool_t reload)
 static switch_status_t
 load_globals (switch_xml_t cfg)
 {
-  globals.ptp_domain = 0;
-  // hacky fix to prevent failing to get ptp from crashing FreeSWITCH
 
   switch_xml_t settings, param;
   if ((settings = switch_xml_child (cfg, "settings"))) {
@@ -2581,9 +2579,12 @@ load_globals (switch_xml_t cfg)
         if (!zstr(iface)) {
           strncpy(globals.ptp_iface, iface, NW_IFACE_LEN - 1);
         }
-	  } else if (!strcasecmp(var, "ptp-interface")) {
-		strncpy(globals.ptp_iface, val, NW_IFACE_LEN - 1);
-	  } else if (!strcasecmp(var, "synthetic-ptp")) {
+      } else if (!strcasecmp(var, "ptp-interface")) {
+        globals.ptp_domain = 0;
+        // hacky fix to prevent failing to get ptp from crashing FreeSWITCH
+
+        strncpy(globals.ptp_iface, val, NW_IFACE_LEN - 1);
+      } else if (!strcasecmp(var, "synthetic-ptp")) {
         globals.synthetic_ptp = atoi(val);
       } else if (!strcasecmp (var, "rtp-ts-offset")) {
         globals.rtp_ts_offset = strtod(val, NULL);

--- a/src/mod/endpoints/mod_aes67/mod_aes67.c
+++ b/src/mod/endpoints/mod_aes67/mod_aes67.c
@@ -2965,7 +2965,8 @@ clear_shared_audio_stream (shared_audio_stream_t * shstream)
 {
   switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
       "Destroying shared audio stream %s\n", shstream->name);
-  stop_pipeline (shstream->stream);
+  if (shstream->stream)
+    stop_pipeline (shstream->stream);
 
   shstream->stream = NULL;
 


### PR DESCRIPTION
- Switch to ptp in the background
  If the ptp sync fails during the init, go ahead
  with the Synthentic PTP and also listen for the PTP clock sync status in the background. If the clock
  sync succeeds, switch all the streams clocks to PTP clock.

  Emit a new event to indicate the change in PTP Grandmaster clock change whenever there a new Grandmaster is selected   using the statistics from the gstptptclock

- Add protection for shared streams list
Initialize a new switch_mutex_t for shared streams list to
synchronize the read/write access to shared streams hash list

- When using with Synthetic PTP, the threadshare version
of the jitterbuffer goes into blocking without pushing the buffers
downstream after a few seconds from the start of the pipeline.
Switch back to the non threadshare version i.e. rtpjitterbuffer
to be more reliable.

- Move setting the ptp domain as 0 only if the `ptp-iface` is set
Setting the ptp domain to 0 unconditionally will prevent us
from disabling PTP in mod_aes67 in case we want to use only
SyntheticPTP and not use PTP master clock.
In case we want to use Synthetic PTP by default, the ptp domain
value should be <0, so set the ptp domain to hardcoded value of 0
only if the ptp-iface variable to set in the configuration
