### PR TITLE
PTP deinit during shutdown

### DIFF
--- a/src/mod/endpoints/mod_aes67/mod_aes67.c
+++ b/src/mod/endpoints/mod_aes67/mod_aes67.c
@@ -2728,12 +2728,10 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION (mod_aes67_shutdown)
   if (globals.ptp_stats_cb_id != -1)
     gst_ptp_statistics_callback_remove(globals.ptp_stats_cb_id);
 
-  // FIXME: deinit is causing SIGABRT while free'ing the domain_clocks list
-  // gst_ptp_deinit();
-
   destroy_audio_streams ();
   destroy_shared_audio_streams ();
   destroy_codecs ();
+  gst_ptp_deinit ();
 
   if (globals.clock)
     gst_object_unref (globals.clock);


### PR DESCRIPTION
This call used to crash SIPServer earlier because of double free
happening within the gstptpclock during the deinit.

This fix works only if the gstreamer build has the fix for double
free in the gstptpclock, else unloading mod_aes67 will crash SIPServer

Here is the gstreamer build to use:
https://drive.google.com/file/d/1yB9ZmLNOZEX3TVjdniCFVA4AtBYf6sa2/view?usp=sharing

Here is the corresponding fix in the gstreamer upstream:
https://gitlab.freedesktop.org/tkanakamalla/gstreamer/-/commit/a813c0cf33a8d222338352c95f099c369e6a70e0