### PR TITLE
Fix for SIPserver crash with invalid endpoints

### DIFF
--- a/src/mod/endpoints/mod_aes67/mod_aes67.c
+++ b/src/mod/endpoints/mod_aes67/mod_aes67.c
@@ -1647,8 +1647,11 @@ error:
 	  if (tech_pvt->write_codec.codec_interface) {
           switch_core_codec_destroy(&tech_pvt->write_codec);
     }
-    switch_mutex_unlock (endpoint->mutex);
   }
+
+  if (endpoint)
+    switch_mutex_unlock (endpoint->mutex);
+
   if (new_session && *new_session) {
     switch_core_session_destroy (new_session);
   }


### PR DESCRIPTION
check endpoint is valid during mutex unlock
In case of error, the endpoint is not valid so trying to access its members is causing the SIPServer crash