### PR TITLE
mod_aes67: drop the tx buffers if there is another sender

### DIFF
--- a/src/mod/endpoints/mod_aes67/aes67_api.h
+++ b/src/mod/endpoints/mod_aes67/aes67_api.h
@@ -44,6 +44,8 @@ typedef struct
   int rtp_jitbuf_latency;
   gboolean txdrop;
   char *ts_context_name;
+  gboolean is_backup_sender;
+  int backup_sender_idle_wait_ms;
 } pipeline_data_t;
 
 struct g_stream
@@ -59,6 +61,10 @@ struct g_stream
   GstClock *clock;
   gint sample_rate;
   char *ts_ctx;
+  gboolean pause_backup_sender;
+  gboolean txdrop;
+  guint backup_sender_idle_timer;
+  int backup_sender_idle_wait_ms;
 };
 
 g_stream_t *create_pipeline (pipeline_data_t *data, event_callback_t * error_cb);

--- a/src/mod/endpoints/mod_aes67/mod_aes67.vcxproj
+++ b/src/mod/endpoints/mod_aes67/mod_aes67.vcxproj
@@ -56,6 +56,7 @@
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\glib-2.0.props" />
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gstreamer-app-1.0.props" />
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gstreamer-net-1.0.props" />
+    <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gio-2.0.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -64,6 +65,7 @@
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\glib-2.0.props" />
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gstreamer-app-1.0.props" />
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gstreamer-net-1.0.props" />
+    <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gio-2.0.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -72,6 +74,7 @@
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\glib-2.0.props" />
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gstreamer-app-1.0.props" />
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gstreamer-net-1.0.props" />
+    <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gio-2.0.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -80,6 +83,7 @@
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\glib-2.0.props" />
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gstreamer-app-1.0.props" />
     <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gstreamer-net-1.0.props" />
+    <Import Project="C:\gstreamer\1.0\msvc_x86_64\share\vs\2010\libs\gio-2.0.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>


### PR DESCRIPTION
This is configurable using two options per stream
1. `is-backup-sender` - set to 0 by default
Use this flag to enable the stream to work as a backup sender. If a stream is configured to work as backup sender, keep listening for the udp packets on the multicast address same as the tx address. Stop transmitting if we receive packets from any sender other than the self

2. `backup-sender-idle-wait-ms` - set to 1000ms by default 
Use the timeout value to switch from being backup to primary sender. Check the timestamp of the buffers received from the remote sender at a particular interval to determine if the buffers are recent or too old.

This requires a new installation of gstreamer, which has a fix to add `loop` property to `ts-udpsrc`. The build can be downloaded from here - https://drive.google.com/file/d/1ijQGEkRI1qKMw2OaeX4iswZm5OtOjaPK/view?usp=sharing