### PR TITLE
Fix for freeze of hupall command while originating many calls rapidly

### DIFF
--- a/src/mod/endpoints/mod_aes67/aes67_api.c
+++ b/src/mod/endpoints/mod_aes67/aes67_api.c
@@ -211,6 +211,18 @@ gboolean update_clock (gpointer userdata) {
   return G_SOURCE_CONTINUE;
 }
 
+/*
+  Creates a new queue and appsink and links them to a new branch (sink pad)
+  of the tee in the Rx pipeline. These are associated to a particular session
+  calling on an endpoint.
+  This allows to accept multiple listeners on single endpoint
+
+  Note: The caller needs to lock the `stream` using `STREAM_READER_LOCK` before
+  calling this function and unlock the `stream` using `STREAM_READER_UNLOCK` after
+  returning from this function
+
+*/
+
 gboolean
 add_appsink (g_stream_t *stream, guint ch_idx, gchar *session)
 {
@@ -322,6 +334,16 @@ add_appsink (g_stream_t *stream, guint ch_idx, gchar *session)
 
   return ret;
 }
+
+/*
+  Unlinks a session's associated queue and appsink from the tee and removes them
+  from the Rx pipeline.
+
+  Note: The caller needs to lock the `stream` using `STREAM_READER_LOCK` before
+  calling this function and unlock the `stream` using `STREAM_READER_UNLOCK` after
+  returning from this function
+
+*/
 
 gboolean
 remove_appsink(g_stream_t *stream, guint ch_idx, gchar *session) {


### PR DESCRIPTION
Move the cleanup of gstreamer elements associated to a session from the channel_kill to channel_hangup so that they can be torn down asynchronously when the HANGUP events are dispatched.

This avoids blocking of the channel_kill which is called while terminating a session using uuid_kill or hupall commands from the fs_cli

The issue is mostly seen when there are multiple sessions being originated and if we issue command to terminate all sessions concurrently.