### PR TITLE
Minor bug fixes

### DIFF
--- a/src/mod/endpoints/mod_aes67/mod_aes67.c
+++ b/src/mod/endpoints/mod_aes67/mod_aes67.c
@@ -1742,8 +1742,14 @@ SWITCH_MODULE_LOAD_FUNCTION (mod_aes67_load)
 	if (realpath(media_dir, media_dir) !=  NULL) {
 #endif
 		switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Resolved the abolute path to Media (GStreamer) path as %s\n", media_dir);
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Setting it as environment variable: GST_PLUGIN_PATH\n");
+    struct stat st_buf;
+    int ret = -1;
+    if (((ret = stat(media_dir, &st_buf)) == 0) && (st_buf.st_mode & S_IFDIR) ) {
+      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Setting it as environment variable: GST_PLUGIN_PATH\n");
     switch_setenv("GST_PLUGIN_PATH", media_dir, TRUE);
+    } else {
+      switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Can't access %s, error: %s. Not overriding GST_PLUGIN_PATH\n", media_dir, strerror(errno));
+    }
 	} else {
 		switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to resolve the Media (GStreamer) path"
 #ifdef _WIN32

--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -2485,7 +2485,14 @@ static void switch_update_media_env_path () {
 	switch_snprintf(variable,MAX_VAR_LEN, "LD_LIBRARY_PATH");
 	if (realpath(media_bin_dir, media_bin_dir) !=  NULL) {
 #endif
-		switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Resolved the abolute path to Media (GStreamer) path as %s\n", media_bin_dir);
+    	struct stat st_buf;
+    	int ret = -1;
+    	if (((ret = stat(media_bin_dir, &st_buf)) == 0) && (st_buf.st_mode & S_IFDIR) ) {
+    		switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Resolved the abolute path to Media (GStreamer) path as %s\n", media_bin_dir);
+    	} else {
+    		switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Can't access %s, error: %s. Not setting it in the %s\n", media_bin_dir, strerror(errno), variable);
+    		return;
+    	}
 	} else {
 		switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to resolve the Media (GStreamer) path"
 #ifdef WIN32


### PR DESCRIPTION
1. Check if `Media` directory exists in mod_dir before adding it to PATH/LD_LIBRARY_PATH and GST_PLUGIN_PATH 

2. Check for `instream` validity during channel hangup
we are trying to remove appsink from instream without checking if there is instream for a given endpoint and that is leading to application crash