### PR TITLE
2026-02-01 Aes67 Memory leakage addressed

### DIFF
--- a/SIPServer/obj/Engine.csproj.nuget.dgspec.json
+++ b/SIPServer/obj/Engine.csproj.nuget.dgspec.json
@@ -1,17 +1,17 @@
 {
   "format": 1,
   "restore": {
-    "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPServer\\Engine.csproj": {}
+    "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPServer\\Engine.csproj": {}
   },
   "projects": {
-    "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPServer\\Engine.csproj": {
+    "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPServer\\Engine.csproj": {
       "version": "1.0.0",
       "restore": {
-        "projectUniqueName": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPServer\\Engine.csproj",
+        "projectUniqueName": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPServer\\Engine.csproj",
         "projectName": "Engine",
-        "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPServer\\Engine.csproj",
+        "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPServer\\Engine.csproj",
         "packagesPath": "C:\\Users\\Administrator\\.nuget\\packages\\",
-        "outputPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPServer\\obj\\",
+        "outputPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPServer\\obj\\",
         "projectStyle": "PackageReference",
         "fallbackFolders": [
           "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
@@ -32,11 +32,11 @@
           "net8.0-windows10.0.22621": {
             "targetAlias": "net8.0-windows10.0.22621.0",
             "projectReferences": {
-              "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
-                "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj"
+              "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
+                "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj"
               },
-              "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj": {
-                "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj"
+              "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj": {
+                "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj"
               }
             }
           }
@@ -118,11 +118,11 @@
         }
       }
     },
-    "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
+    "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
       "restore": {
-        "projectUniqueName": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj",
+        "projectUniqueName": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj",
         "projectName": "FreeSWITCH.Managed.2017",
-        "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj",
+        "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj",
         "frameworks": {
           "net48": {
             "projectReferences": {}
@@ -133,16 +133,16 @@
         "net48": {}
       }
     },
-    "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj": {
+    "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj": {
       "restore": {
-        "projectUniqueName": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj",
+        "projectUniqueName": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj",
         "projectName": "mod_managed",
-        "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj",
+        "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj",
         "frameworks": {
           "native": {
             "projectReferences": {
-              "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
-                "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj"
+              "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
+                "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj"
               }
             }
           }

--- a/SIPServer/obj/project.assets.json
+++ b/SIPServer/obj/project.assets.json
@@ -2049,11 +2049,11 @@
   "project": {
     "version": "1.0.0",
     "restore": {
-      "projectUniqueName": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPServer\\Engine.csproj",
+      "projectUniqueName": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPServer\\Engine.csproj",
       "projectName": "Engine",
-      "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPServer\\Engine.csproj",
+      "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPServer\\Engine.csproj",
       "packagesPath": "C:\\Users\\Administrator\\.nuget\\packages\\",
-      "outputPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPServer\\obj\\",
+      "outputPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPServer\\obj\\",
       "projectStyle": "PackageReference",
       "fallbackFolders": [
         "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
@@ -2074,11 +2074,11 @@
         "net8.0-windows10.0.22621": {
           "targetAlias": "net8.0-windows10.0.22621.0",
           "projectReferences": {
-            "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
-              "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj"
+            "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
+              "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj"
             },
-            "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj": {
-              "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj"
+            "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj": {
+              "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\mod_managed.2017.vcxproj"
             }
           }
         }

--- a/SIPWebServer/obj/SIPWebServer.csproj.nuget.dgspec.json
+++ b/SIPWebServer/obj/SIPWebServer.csproj.nuget.dgspec.json
@@ -1,17 +1,17 @@
 {
   "format": 1,
   "restore": {
-    "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPWebServer\\SIPWebServer.csproj": {}
+    "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPWebServer\\SIPWebServer.csproj": {}
   },
   "projects": {
-    "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPWebServer\\SIPWebServer.csproj": {
+    "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPWebServer\\SIPWebServer.csproj": {
       "version": "1.0.0",
       "restore": {
-        "projectUniqueName": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPWebServer\\SIPWebServer.csproj",
+        "projectUniqueName": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPWebServer\\SIPWebServer.csproj",
         "projectName": "SIPWebServer",
-        "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPWebServer\\SIPWebServer.csproj",
+        "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPWebServer\\SIPWebServer.csproj",
         "packagesPath": "C:\\Users\\Administrator\\.nuget\\packages\\",
-        "outputPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPWebServer\\obj\\",
+        "outputPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPWebServer\\obj\\",
         "projectStyle": "PackageReference",
         "fallbackFolders": [
           "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
@@ -32,8 +32,8 @@
           "net8.0": {
             "targetAlias": "net8.0",
             "projectReferences": {
-              "C:\\Development\\GitHub\\SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
-                "projectPath": "C:\\Development\\GitHub\\SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj"
+              "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
+                "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj"
               }
             }
           }
@@ -119,11 +119,11 @@
         }
       }
     },
-    "C:\\Development\\GitHub\\SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
+    "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
       "restore": {
-        "projectUniqueName": "C:\\Development\\GitHub\\SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj",
+        "projectUniqueName": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj",
         "projectName": "FreeSWITCH.Managed.2017",
-        "projectPath": "C:\\Development\\GitHub\\SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj",
+        "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj",
         "frameworks": {
           "net48": {
             "projectReferences": {}

--- a/SIPWebServer/obj/project.assets.json
+++ b/SIPWebServer/obj/project.assets.json
@@ -4668,11 +4668,11 @@
   "project": {
     "version": "1.0.0",
     "restore": {
-      "projectUniqueName": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPWebServer\\SIPWebServer.csproj",
+      "projectUniqueName": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPWebServer\\SIPWebServer.csproj",
       "projectName": "SIPWebServer",
-      "projectPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPWebServer\\SIPWebServer.csproj",
+      "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPWebServer\\SIPWebServer.csproj",
       "packagesPath": "C:\\Users\\Administrator\\.nuget\\packages\\",
-      "outputPath": "C:\\Development\\GitHub\\GERRAudio\\DO-NOT-RELEASE-networked-audio-SIPServer\\SIPWebServer\\obj\\",
+      "outputPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\SIPWebServer\\obj\\",
       "projectStyle": "PackageReference",
       "fallbackFolders": [
         "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
@@ -4693,8 +4693,8 @@
         "net8.0": {
           "targetAlias": "net8.0",
           "projectReferences": {
-            "C:\\Development\\GitHub\\SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
-              "projectPath": "C:\\Development\\GitHub\\SIPServer\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj"
+            "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj": {
+              "projectPath": "C:\\Development\\GitHub\\networkedaudio\\SIPServer-update-fork\\src\\mod\\languages\\mod_managed\\managed\\FreeSWITCH.Managed.2017.csproj"
             }
           }
         }

--- a/src/mod/endpoints/mod_aes67/aes67_alloc.h
+++ b/src/mod/endpoints/mod_aes67/aes67_alloc.h
@@ -1,0 +1,423 @@
+// Wrappers to track allocations/deallocations (debug)
+// allows display the counters from the CLI : use "aes67 allocs"
+// also to wrap sensitive gstreamer calls with mutexes as recommended by gst documentation
+//
+// to use, prefix functions that are allocators with AL_  and deallocators with DA_. Most AL DA can use mutexes as well
+// MU_ just mutexes the call with an appropriate mutex (hardcoded here)
+//
+// NB - the dealloc/deref  wrappers always check if the passed ptr is NULL first
+//
+// todo:
+// - use flags to remove mutexes
+// - use flags to disable counters
+//
+// Copyright GERRAudio 2025-2026
+//
+#ifndef G_WRAP
+#define G_WRAP
+
+#include "aes67_counters.h"
+#include <glib.h>
+#include <gst/app/gstappsink.h>
+#include <gst/audio/audio-channels.h>
+#include <gst/gst.h>
+#include <stdarg.h>
+
+// specialized mutexes, must be declared and initialized in c module where MU_ functions are used
+
+// extern switch_mutex_t *general_pipl_lock;
+
+// extern switch_mutex_t *alloc_mcp_lock;
+// extern switch_mutex_t *alloc_bkup_lock;
+
+// Atomic incr/decr for debugging only
+// forces serialization of counters
+// slower and not useful except for debug but validates leaks
+// can be changed if performance impacted (not likely)
+#define ATOMIC_COUNTS 1
+#ifdef ATOMIC_COUNTS
+#include <glib.h>
+#define G_ATOMIC_LOCK_FREE
+inline void g_atomic_int_dec(int *i) { g_atomic_int_add(i, -1); }
+#define accounting_incr(c) g_atomic_int_inc(&c)
+#define accounting_decr(c) g_atomic_int_dec(&c)
+#else
+#define accounting_incr(c) (c++)
+#define accounting_decr(c) (c--)
+#endif
+
+// --- Macro for allocation wrappers ---
+#define G_WRAP_ALLOC(ret_type, func, counter, tp1, p1)                                                                 \
+	inline ret_type AL_##func(tp1 p1)                                                                                  \
+	{                                                                                                                  \
+		ret_type _ret = func(p1);                                                                                      \
+		if (_ret) accounting_incr(g_alloc_counts.counter);                                                             \
+		return _ret;                                                                                                   \
+	}
+
+// with mutex
+#define G_WRAP_ALLOC_M(ret_type, func, counter, tp1, p1, l)                                                            \
+	inline ret_type AL_##func(tp1 p1)                                                                                  \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		ret_type _ret = func(p1);                                                                                      \
+		if (_ret) accounting_incr(g_alloc_counts.counter);                                                             \
+		switch_mutex_unlock(l);                                                                                        \
+		return _ret;                                                                                                   \
+	}
+
+// allocators
+#define G_WRAP_ALLOC2(ret_type, func, counter, tp1, p1, tp2, p2)                                                       \
+	inline ret_type AL_##func(tp1 p1, tp2 p2)                                                                          \
+	{                                                                                                                  \
+		ret_type _ret = func(p1, p2);                                                                                  \
+		if (_ret) accounting_incr(g_alloc_counts.counter);                                                             \
+		return _ret;                                                                                                   \
+	}
+// with mutex
+#define G_WRAP_ALLOC2_M(ret_type, func, counter, tp1, p1, tp2, p2, l)                                                  \
+	inline ret_type AL_##func(tp1 p1, tp2 p2)                                                                          \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		ret_type _ret = func(p1, p2);                                                                                  \
+		if (_ret) accounting_incr(g_alloc_counts.counter);                                                             \
+		switch_mutex_unlock(l);                                                                                        \
+		return _ret;                                                                                                   \
+	}
+
+#define G_WRAP_ALLOC3(ret_type, func, counter, tp1, p1, tp2, p2, tp3, p3)                                              \
+	inline ret_type AL_##func(tp1 p1, tp2 p2, tp3 p3)                                                                  \
+	{                                                                                                                  \
+		ret_type _ret = func(p1, p2, p3);                                                                              \
+		if (_ret) accounting_incr(g_alloc_counts.counter);                                                             \
+		return _ret;                                                                                                   \
+	}
+// with mutex
+#define G_WRAP_ALLOC3_M(ret_type, func, counter, tp1, p1, tp2, p2, tp3, p3, l)                                         \
+	inline ret_type AL_##func(tp1 p1, tp2 p2, tp3 p3)                                                                  \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		ret_type _ret = func(p1, p2, p3);                                                                              \
+		if (_ret) accounting_incr(g_alloc_counts.counter);                                                             \
+		switch_mutex_unlock(l);                                                                                        \
+		return _ret;                                                                                                   \
+	}
+
+#define G_WRAP_ALLOC4(ret_type, func, counter, tp1, p1, tp2, p2, tp3, p3, tp4, p4)                                     \
+	inline ret_type AL_##func(tp1 p1, tp2 p2, tp3 p3, tp4 p4)                                                          \
+	{                                                                                                                  \
+		ret_type _ret = func(p1, p2, p3, p4);                                                                          \
+		if (_ret) accounting_incr(g_alloc_counts.counter);                                                             \
+		return _ret;                                                                                                   \
+	}
+
+#define G_WRAP_ALLOC7(ret_type, func, counter, tp1, p1, tp2, p2, tp3, p3, tp4, p4, tp5, p5, tp6, p6, tp7, p7)          \
+	inline ret_type AL_##func(tp1 p1, tp2 p2, tp3 p3, tp4 p4, tp5 p5, tp6 p6, tp7 p7)                                  \
+	{                                                                                                                  \
+		ret_type _ret = func(p1, p2, p3, p4, p5, p6, p7);                                                              \
+		if (_ret) accounting_incr(g_alloc_counts.counter);                                                             \
+		return _ret;                                                                                                   \
+	}
+
+// TODO define
+// G_WRAP_ALLOC2(GstPad *, gst_element_get_request_pad, pads, GstElement *, e, const gchar *, n)
+// G_WRAP_ALLOC2(GstPad *, gst_element_get_static_pad, pads, GstElement *, e, const gchar *, n)
+// G_WRAP_ALLOC(GstPad *, gst_pad_get_peer, pads, GstPad *, p)
+
+// used to wrap deallocators to set ptr to NULL
+#define DEC_objs_forceNULL(a)                                                                                          \
+	do {                                                                                                               \
+		if (a) {                                                                                                       \
+			DA_dec_objs(a);                                                                                            \
+			a = NULL;                                                                                                  \
+		}                                                                                                              \
+	} while (0);
+
+// --- Macro for deallocation wrappers ---
+// the nulling will not work unless I do weird & stuff - worked around it
+#define G_WRAP_FREE(fname, counter, arg_type)                                                                          \
+	inline void DA_##fname(arg_type p)                                                                                 \
+	{                                                                                                                  \
+		if (p != NULL) {                                                                                               \
+			fname(p);                                                                                                  \
+			accounting_decr(g_alloc_counts.counter);                                                                   \
+		}                                                                                                              \
+	}
+
+//
+// ==== incr/decr to use when wrapping is undesired
+// --- Macro for increment-only wrappers (for manual tracking) ---
+#define G_WRAP_INC(counter, name, t, p)                                                                                \
+	inline void AL_##name(t p) { accounting_incr(g_alloc_counts.counter); }
+// --- Sample increment wrapper ---
+// G_WRAP_INC(samples, cnt_samples, GstSample *, p)
+
+// --- Macro for decrement-only wrappers (for manual tracking) ---
+// the nulling will not work due to the function
+#define G_WRAP_DEC(counter, name, t, p)                                                                                \
+	inline void DA_##name(t p)                                                                                         \
+	{                                                                                                                  \
+		if (p) { accounting_decr(g_alloc_counts.counter); }                                                            \
+	}
+
+// --- Macro for decrement-only wrappers no nulling (for manual tracking and accounting) ---
+// can be disabled
+#define COUNT_OBJS 1
+#ifdef COUNT_OBJS
+#define G_WRAP_DECNN(counter, name, t, p)                                                                              \
+	inline void DA_NoNulling_##name(t p) { accounting_decr(g_alloc_counts.counter); }
+#else
+#define G_WRAP_DECNN(counter, name, t, p)                                                                              \
+	inline void DA_NoNulling_##name(t p) { ; }
+#endif
+
+//==== Mutex wrappers
+//
+#define MU_WRAP1(ret_type, fname, tp1, p1, l)                                                                          \
+	inline ret_type MU_##fname(tp1 p1)                                                                                 \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		ret_type retval = fname(p1);                                                                                   \
+		switch_mutex_unlock(l);                                                                                        \
+		return retval;                                                                                                 \
+	}
+
+// void return
+#define MU_WRAPV1c(fname, tp1, p1, l)                                                                                  \
+	inline void MUc_##fname(tp1 p1)                                                                                    \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		fname(p1);                                                                                                     \
+		switch_mutex_unlock(l);                                                                                        \
+	}
+
+#define MU_WRAPV1p(fname, tp1, p1, l)                                                                                  \
+	inline void MUp_##fname(tp1 p1)                                                                                    \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		fname(p1);                                                                                                     \
+		switch_mutex_unlock(l);                                                                                        \
+	}
+
+#define MU_WRAP2(ret_type, fname, tp1, p1, tp2, p2, l)                                                                 \
+	inline ret_type MU_##fname(tp1 p1, tp2 p2)                                                                         \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		ret_type retval = fname(p1, p2);                                                                               \
+		switch_mutex_unlock(l);                                                                                        \
+		return retval;                                                                                                 \
+	}
+
+// void return
+#define MU_WRAPV2(fname, tp1, p1, tp2, p2, l)                                                                          \
+	inline void MU_##fname(tp1 p1, tp2 p2)                                                                             \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		fname(p1, p2);                                                                                                 \
+		switch_mutex_unlock(l);                                                                                        \
+	}
+
+#define MU_WRAPV2p(fname, tp1, p1, tp2, p2, l)                                                                         \
+	inline void MUp_##fname(tp1 p1, tp2 p2)                                                                            \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		fname(p1, p2);                                                                                                 \
+		switch_mutex_unlock(l);                                                                                        \
+	}
+
+// MU_WRAPV2p(gst_element_release_request_pad, GstElement *, element, GstPad *, p, general_pipl_lock)
+
+#define MU_WRAP3(ret_type, fname, tp1, p1, tp2, p2, tp3, p3, l)                                                        \
+	inline ret_type MU_##fname(tp1 p1, tp2 p2, tp3 p3)                                                                 \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		ret_type retval = fname(p1, p2, p3);                                                                           \
+		switch_mutex_unlock(l);                                                                                        \
+	}
+
+#define MU_WRAP3S(ret_type, fname, t1, p1, t2, p2, t3, p3, l)                                                          \
+	inline ret_type MU3_##fname(t1 p1, t2 p2, t3 p3)                                                                   \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		ret_type _result = fname(p1, p2, p3);                                                                          \
+		switch_mutex_unlock(l);                                                                                        \
+		return _result;                                                                                                \
+	}
+
+// void return
+#define MU_WRAPV3(fname, tp1, p1, tp2, p2, tp3, p3, l)                                                                 \
+	inline void MU_##fname(tp1 p1, tp2 p2, tp3 p3)                                                                     \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		fname(p1, p2, p3);                                                                                             \
+		switch_mutex_unlock(l);                                                                                        \
+	}
+
+#define MU_WRAP4(ret_type, fname, tp1, p1, tp2, p2, tp3, p3, tp4, p4, l)                                               \
+	inline ret_type MU_##fname(tp1 p1, tp2 p2, tp3 p3, tp4 p4)                                                         \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		ret_type retval = fname(p1, p2, p3, p4);                                                                       \
+		switch_mutex_unlock(l);                                                                                        \
+		return retval;                                                                                                 \
+	}
+
+#define MU_WRAP7(ret_type, fname, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, l)                           \
+	inline ret_type MU_##fname(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7)                                        \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		ret_type _result = fname(p1, p2, p3, p4, p5, p6, p7);                                                          \
+		switch_mutex_unlock(l);                                                                                        \
+		return _result;                                                                                                \
+	}
+
+#define MU_WRAP8S(ret_type, fname, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, t8, p8, l)                  \
+	inline ret_type MU8_##fname(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8)                                \
+	{                                                                                                                  \
+		switch_mutex_lock(l);                                                                                          \
+		ret_type _result = fname(p1, p2, p3, p4, p5, p6, p7, p8);                                                      \
+		switch_mutex_unlock(l);                                                                                        \
+		return _result;                                                                                                \
+	}
+
+// ===
+// gst functions that may require mutexes
+//
+//  === memcpy lock
+// void *memcpy(void *dest, const void *src, size_t n);
+// MU_WRAPV3(memcpy, void *, dest, const void *, src, size_t, n, alloc_mcp_lock)
+
+// ===element (obj) locks
+
+// MU_WRAP2(gboolean, gst_bin_add, GstBin *, bin, GstElement *, element, general_pipl_lock)
+
+#define MU_g_object_set(p1, ...)                                                                                       \
+	do {                                                                                                               \
+		switch_mutex_lock(alloc_elem_lock);                                                                            \
+		g_object_set(p1, __VA_ARGS__);                                                                                 \
+		switch_mutex_unlock(alloc_elem_lock);                                                                          \
+	} while (0)
+
+// void gst_bin_add_many (GstBin *bin, GstElement *element_1, ...);
+#define MU_gst_bin_add_many(p1, ...)                                                                                   \
+	do {                                                                                                               \
+		switch_mutex_lock(alloc_elem_lock);                                                                            \
+		gst_bin_add_many(p1, __VA_ARGS__);                                                                             \
+		switch_mutex_unlock(alloc_elem_lock);                                                                          \
+	} while (0)
+
+// G_WRAP_INC(objs, cnt_objs, gpointer, p)
+//  chars
+// G_WRAP_INC(chars, cnt_chars, gchar *, p)
+
+G_WRAP_FREE(g_free, chars, gpointer)
+// G_WRAP_ALLOC(gpointer, g_malloc0, chars, gsize, c)
+// G_WRAP_ALLOC(gchar *, g_strdup, chars, gchar *, str)
+// G_WRAP_ALLOC(gchar *, gst_structure_to_string, chars, const GstStructure *, s)
+
+// --- inc/dec wrappers ---
+// G_WRAP_INC(bufs, cnt_bufs, GstStructure *, p)
+G_WRAP_INC(samples, cnt_samples, GstSample *, p)
+G_WRAP_DEC(bufs, dec_bufs, GstBuffer *, p)
+G_WRAP_DECNN(bufs, dec_bufs, GstBuffer *, p)
+G_WRAP_DECNN(objs, dec_objs, GstElement *, p)
+G_WRAP_DECNN(caps, dec_caps, GstCaps *, p)
+// G_WRAP_DECNN(chars, dec_chars, gchar *, c)
+
+// --- Structure wrappers ---
+G_WRAP_INC(structs, cnt_structs, GstStructure *, p)
+G_WRAP_FREE(gst_structure_free, structs, GstStructure *)
+
+G_WRAP_ALLOC(GstStructure *, gst_structure_copy, structs, const GstStructure *, s)
+G_WRAP_ALLOC(GstStructure *, gst_structure_new_empty, structs, const gchar *, name)
+//
+// no macro for variadic function below
+//
+inline GstStructure *AL_gst_structure_new(const gchar *name, const gchar *first, ...)
+{
+	va_list args;
+	va_start(args, first);
+	GstStructure *s = gst_structure_new_valist(name, first, args);
+	va_end(args);
+	if (s) g_alloc_counts.structs++;
+	return s;
+}
+
+// --- Error wrappers ---
+G_WRAP_INC(errs, cnt_errs, GError *, p)
+G_WRAP_FREE(g_error_free, errs, GError *)
+
+// --- Object wrappers ---
+G_WRAP_FREE(gst_object_unref, objs, GstObject *)
+
+G_WRAP_DEC(objs, dec_objs, GstObject *, p)
+G_WRAP_DEC(caps, dec_caps, GstCaps *, p)
+G_WRAP_DEC(samples, dec_samples, GstSample *, p)
+
+// G_WRAP_INC(objs, cnt_objs, GstObject *, p)
+G_WRAP_INC(objs, cnt_caps, GstCaps *, p)
+
+G_WRAP_ALLOC(GstBus *, gst_pipeline_get_bus, objs, GstPipeline *, b)
+G_WRAP_ALLOC2(GstElement *, gst_bin_get_by_name, objs, GstBin *, bin, const gchar *, n)
+G_WRAP_ALLOC(GstElement *, gst_pipeline_new, objs, const gchar *, n)
+// Add to document 3
+G_WRAP_ALLOC3(GstBuffer *, gst_buffer_new_allocate, bufs, GstAllocator *, allocator, gsize, size, GstAllocationParams *, params)
+G_WRAP_ALLOC2(GstElement *, gst_element_factory_make, objs, const gchar *, factoryname, const gchar *, name)
+// G_WRAP_ALLOC2(GstPad *, gst_element_get_static_pad, objs, GstElement *, e, const gchar *, n)
+// G_WRAP_ALLOC2(GstPad *, gst_element_request_pad_simple, objs, GstElement *, e, const gchar *, n)
+// G_WRAP_ALLOC(GstPad *, gst_pad_get_peer, objs, GstPad *, p)
+// G_WRAP_ALLOC2(GstSample *, gst_app_sink_try_pull_sample, samples, GstAppSink *, sink, GstClockTime, timeout)
+
+G_WRAP_ALLOC2(GstPad *, gst_element_get_request_pad, objs, GstElement *, e, const gchar *, n)
+G_WRAP_ALLOC2(GstPad *, gst_element_request_pad_simple, objs, GstElement *, e, const gchar *, n)
+G_WRAP_ALLOC2(GstPad *, gst_element_get_static_pad, objs, GstElement *, e, const gchar *, n)
+G_WRAP_ALLOC(GstPad *, gst_pad_get_peer, objs, GstPad *, p)
+// Add after other pad wrappers
+
+// ===pipeline locks
+
+// gboolean gst_pipeline_set_clock(GstPipeline *pipeline, GstClock *clock);
+// MU_WRAP2(gboolean, gst_pipeline_set_clock, GstPipeline *, p, GstClock *, c, general_pipl_lock)
+// void gst_pipeline_use_clock(GstPipeline *pipeline, GstClock *clock);
+// MU_WRAPV2(gst_pipeline_use_clock, GstPipeline *, pipeline, GstClock *, clock, general_pipl_lock)
+// gst_object_unref(GST_OBJECT(stream->pipeline));
+// MU_WRAPV1p(gst_object_unref, gpointer, pipeline, general_pipl_lock)
+// gboolean gst_bin_remove(GstBin *bin, GstElement *element);
+// MU_WRAP2(gboolean, gst_bin_remove, GstBin *, bin, GstElement *, element, general_pipl_lock)
+// GstStateChangeReturn gst_element_get_state(GstElement *e, GstState *s,GstState *pending, GstClockTime timeout);
+// MU_WRAP4(GstStateChangeReturn, gst_element_get_state, GstElement *, e, GstState *, s, GstState *, p, GstClockTime,t, general_pipl_lock)
+// gboolean gst_bus_remove_watch(GstBus *bus);
+// MU_WRAP1(gboolean, gst_bus_remove_watch, GstBus *, bus, general_pipl_lock)
+// GstObject* gst_element_get_parent(GstElement *element);
+G_WRAP_ALLOC(GstObject *, gst_element_get_parent, objs, GstElement *, e)
+// --- Sample  wrappers ---
+G_WRAP_FREE(gst_sample_unref, samples, GstSample *)
+
+// --- caps wrappers ---
+G_WRAP_FREE(gst_caps_unref, caps, GstCaps *)
+G_WRAP_ALLOC(GstCaps *, gst_caps_copy, caps, GstCaps *, c)
+
+// --- buffer wrapper ---
+G_WRAP_FREE(gst_buffer_unref, bufs, GstBuffer *)
+// G_WRAP_ALLOC(GstBuffer *, gst_sample_get_buffer, bufs, GstBuffer *, b)
+
+// Pad name allocation
+G_WRAP_ALLOC(gchar *, gst_pad_get_name, chars, GstPad *, p)
+
+// Clock allocations
+G_WRAP_ALLOC(GstClock *, gst_element_get_clock, objs, GstElement *, e)
+
+// Network string allocation
+// G_WRAP_ALLOC(gchar *, g_inet_address_to_string, chars, GInetAddress *, addr)
+// G_WRAP_ALLOC2(GstClock*, gst_ptp_clock_new, objs, const gchar*, name, guint, domain)
+
+inline GstClock *AL_g_object_new_clock(GType object_type, const gchar *first_prop, ...)
+{
+	va_list args;
+	va_start(args, first_prop);
+	GstClock *clock = (GstClock *)g_object_new_valist(object_type, first_prop, args);
+	va_end(args);
+	if (clock) g_alloc_counts.objs++;
+	return clock;
+}
+#endif

--- a/src/mod/endpoints/mod_aes67/aes67_api.c
+++ b/src/mod/endpoints/mod_aes67/aes67_api.c
@@ -1,22 +1,22 @@
-#include <switch.h>
-
+#include "aes67_api.h"
 #include <gst/app/gstappsink.h>
 #include <gst/audio/audio-channels.h>
 #include <gst/net/net.h>
-#include "aes67_api.h"
+
+#include "aes67_alloc.h"					// allocation tracker and mutex wrappers
+volatile G_alloc_counts g_alloc_counts={0}; // debug counters for allocation
 
 #define ELEMENT_NAME_SIZE 30 + SESSION_ID_LEN
 #define STR_SIZE 15
-#define NAME_ELEMENT(name, element, ch_idx) \
-    g_snprintf(name, ELEMENT_NAME_SIZE, "%s-ch%u", element, ch_idx)
+#define NAME_ELEMENT(name, element, ch_idx) g_snprintf(name, ELEMENT_NAME_SIZE, "%s-ch%u", element, ch_idx)
 
-#define NAME_SESSION_ELEMENT(name, element, ch_idx, sess_id) \
-  do { \
-    if (sess_id != NULL) \
-      g_snprintf(name, ELEMENT_NAME_SIZE, "%s-ch%u-sess%s", element, ch_idx, sess_id); \
-    else \
-      g_snprintf(name, ELEMENT_NAME_SIZE, "%s-ch%u", element, ch_idx); \
-  } while (0)
+#define NAME_SESSION_ELEMENT(name, element, ch_idx, sess_id)                                                           \
+	do {                                                                                                               \
+		if (sess_id != NULL)                                                                                           \
+			g_snprintf(name, ELEMENT_NAME_SIZE, "%s-ch%u-sess%s", element, ch_idx, sess_id);                           \
+		else                                                                                                           \
+			g_snprintf(name, ELEMENT_NAME_SIZE, "%s-ch%u", element, ch_idx);                                           \
+	} while (0)
 
 #define RTP_DEPAY "rx-depay"
 
@@ -28,188 +28,215 @@
 
 #define ENABLE_THREADSHARE
 #define DEFAULT_CONTEXT_NAME "ts"
-#define DEFAULT_CONTEXT_WAIT 10 // ms
+#define DEFAULT_CONTEXT_WAIT 10		// ms
 
-#define MAKE_TS_ELEMENT(var, factory, name, context) \
-  do { \
-    var = gst_element_factory_make (factory, name); \
-    g_object_set(var, "context-wait", DEFAULT_CONTEXT_WAIT, \
-        "context", context, NULL); \
-  } while (0)
+#define MAKE_TS_ELEMENT(var, factory, name, context)                                                                   \
+	do {                                                                                                               \
+		var = AL_gst_element_factory_make(factory, name);                                                              \
+		g_object_set(var, "context-wait", DEFAULT_CONTEXT_WAIT, "context", context, NULL);                             \
+	} while (0)
 
 typedef struct channel_remap channel_remap_t;
 
 struct channel_remap {
-  int channels;
-  // map[input channel index] = output channel index;
-  int map[MAX_IO_CHANNELS];
+	int channels;
+	// map[input channel index] = output channel index;
+	int map[MAX_IO_CHANNELS];
 };
 
 // Based on gst_rtp_channel_orders in gstrtpchannels.c
 channel_remap_t channel_remaps[] = {
-  {
-    .channels = 5,
-    .map = { 0, 1, 4, 2, 3 },
-  },
+	{
+		.channels = 5,
+		.map = {0, 1, 4, 2, 3},
+	},
 };
 
-void
-dump_pipeline (GstPipeline *pipe, const char *name)
+void dump_pipeline(GstPipeline *pipe, const char *name)
 {
-  char *tmp = g_strdup_printf("%s-%s", gst_element_get_name(pipe), name);
+	char *tmp = g_strdup_printf("%s-%s", gst_element_get_name(pipe), name);
+	GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(pipe), GST_DEBUG_GRAPH_SHOW_ALL, tmp);
 
-  GST_DEBUG_BIN_TO_DOT_FILE (GST_BIN (pipe),
-      GST_DEBUG_GRAPH_SHOW_ALL, tmp);
-
-  g_free(tmp);
+	g_free(tmp);
 }
 
-static gboolean
-bus_callback (GstBus * bus, GstMessage * msg, gpointer data)
+static gboolean bus_callback(GstBus *bus, GstMessage *msg, gpointer data)
 {
+	g_stream_t *stream = (g_stream_t *)data;
+	GstElement *pipeline = (GstElement *)stream->pipeline;
+	switch (GST_MESSAGE_TYPE(msg)) {
 
-  g_stream_t *stream = (g_stream_t *) data;
-  GstElement *pipeline = (GstElement *) stream->pipeline;
-  switch (GST_MESSAGE_TYPE (msg)) {
+	case GST_MESSAGE_EOS:
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "End of stream\n");
+		gst_element_set_state(pipeline, GST_STATE_NULL);
+		break;
 
-    case GST_MESSAGE_EOS:
-      switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
-          "End of stream\n");
-      gst_element_set_state (pipeline, GST_STATE_NULL);
-      break;
+	case GST_MESSAGE_ERROR: {
+		gchar *debug = NULL;
+		GError *error = NULL;
 
-    case GST_MESSAGE_ERROR:{
-      gchar *debug;
-      GError *error;
+		gst_message_parse_error(msg, &error, &debug);
+		g_free(debug);
+		debug = NULL;
 
-      gst_message_parse_error (msg, &error, &debug);
-      g_free (debug);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error: %s\n", error->message);
+		if (stream->error_cb) 
+			stream->error_cb(error->message, stream);
+		g_error_free(error);
 
-      switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error: %s\n",
-          error->message);
-      if (stream->error_cb)
-        stream->error_cb (error->message, stream);
-      g_error_free (error);
+		gst_element_set_state(pipeline, GST_STATE_NULL);
+		break;
+	}
+	case GST_MESSAGE_STATE_CHANGED: {
+		GstState old, new, pending;
+		GstPipeline *pipe = stream->pipeline;
+		gst_message_parse_state_changed(msg, &old, &new, &pending);
+		if (msg->src == (GstObject *)pipe) {
+			gchar *old_state = NULL;
+			gchar *new_state = NULL;
+			gchar *transition = NULL;
+			guint len = 0;
+			old_state = g_strdup(gst_element_state_get_name(old));
+			new_state = g_strdup(gst_element_state_get_name(new));
+			len = (guint)(strlen(old_state) + strlen(new_state) + strlen("_to_") + 5);
+			transition = g_malloc0(len);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Pipeline %s changed state from %s to %s\n",
+							  GST_OBJECT_NAME(msg->src), old_state, new_state);
+			g_snprintf(transition, len, "%s_to_%s", old_state, new_state);
+			dump_pipeline(pipe, transition);
+			g_free(old_state);		//not counted
+			old_state = NULL;
+			g_free(new_state);		//not counted
+			new_state = NULL;
+			g_free(transition);		//not counted
+			transition = NULL;
+		}
+		break;
+	}
+	default:
+		break;
+	}
 
-      gst_element_set_state (pipeline, GST_STATE_NULL);
-      break;
-    }
-    case GST_MESSAGE_STATE_CHANGED:{
-      GstState old, new, pending;
-      GstPipeline *pipe = stream->pipeline;
-      gst_message_parse_state_changed (msg, &old, &new, &pending);
-      if (msg->src == (GstObject *) pipe) {
-        gchar *old_state, *new_state, *transition;
-        guint len = 0;
-        old_state = g_strdup (gst_element_state_get_name (old));
-        new_state = g_strdup (gst_element_state_get_name (new));
-        len = strlen (old_state) + strlen (new_state) + strlen ("_to_") + 5;
-        transition = g_malloc0 (len);
-        switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
-            "Pipeline %s changed state from %s to %s\n",
-            GST_OBJECT_NAME (msg->src), old_state, new_state);
-        g_snprintf (transition, len, "%s_to_%s", old_state, new_state);
-        dump_pipeline(pipe, transition);
-        g_free (old_state);
-        g_free (new_state);
-        g_free (transition);
-      }
-      break;
-    }
-    default:
-      break;
-  }
-
-  return TRUE;
-
+	return TRUE;
 }
 
 #ifdef ENABLE_THREADSHARE
-static GstCaps *
-request_pt_map(GstElement *jitterbuffer, guint pt, gpointer user_data)
+static GstCaps *request_pt_map(GstElement *jitterbuffer, guint pt, gpointer user_data)
 {
-  GstCaps *caps = GST_CAPS(user_data), *ret;
+	GstCaps *caps = GST_CAPS(user_data);
+	GstCaps *ret = NULL;
 
-  ret = gst_caps_copy(caps);
-  gst_caps_set_simple(ret, "payload", G_TYPE_INT, pt, NULL);
+	ret = AL_gst_caps_copy(caps);
+	gst_caps_set_simple(ret, "payload", G_TYPE_INT, pt, NULL);
 
-  return ret;
+	return ret;
 }
 
-static void
-destroy_caps(void *data, GClosure G_GNUC_UNUSED *closure)
+static void destroy_caps(void *data, GClosure G_GNUC_UNUSED *closure)
 {
-  if (data !=NULL) gst_caps_unref(GST_CAPS(data));
+	if (data != NULL) {
+		DA_gst_caps_unref(GST_CAPS(data));
+	}
 }
 #endif
 
-static void
-deinterleave_pad_added (GstElement * deinterleave, GstPad * pad,
-    gpointer userdata)
+static void deinterleave_pad_added(GstElement *deinterleave, GstPad *pad, gpointer userdata)
 {
-  GstElement *pipeline = GST_ELEMENT(gst_element_get_parent(deinterleave));
-  GstElement *tee=NULL;
-  GstPad *tee_sink_pad =NULL;
-  gchar name[ELEMENT_NAME_SIZE];
-  gchar *pad_name = NULL;  
-  guint ch_idx;
+	g_stream_t *stream = (g_stream_t *)userdata;
 
-  pad_name = gst_pad_get_name (pad);
-  sscanf (pad_name, "src_%u", &ch_idx);
+	// Check if shutdown is in progress BEFORE any allocations
+	if (!stream || !g_atomic_int_get(&stream->pipeline_active)) {
+		goto done; // Bail immediately, no allocations
+	}
 
-  NAME_ELEMENT (name, "tee", ch_idx);
-  tee = gst_bin_get_by_name (GST_BIN (pipeline), name);  //no allocation
-  g_assert_nonnull (tee);
 
-  tee_sink_pad = gst_element_get_static_pad (tee, "sink");
+	GstElement *pipeline = NULL; 
 
-  if (gst_pad_link (pad, tee_sink_pad) != GST_PAD_LINK_OK) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to link deinterleave %s pad in the rx pipeline", pad_name);
-  }
+	GstElement *tee = NULL;
+	GstPad *tee_sink_pad = NULL;
+	gchar name[ELEMENT_NAME_SIZE];
+	gchar *pad_name = NULL;
+	guint ch_idx;
 
-  dump_pipeline(GST_PIPELINE(pipeline), pad_name);
 
-  // these need to be unconditionally deref'd
-  gst_object_unref (GST_OBJECT(tee_sink_pad));
-  gst_object_unref(GST_OBJECT(tee));
-  gst_object_unref(GST_OBJECT(pipeline));
-  g_free (pad_name);
+	// no check for shutdown in progress here
+
+	pipeline = GST_ELEMENT(AL_gst_element_get_parent(deinterleave));		
+	pad_name = AL_gst_pad_get_name(pad);
+	if(sscanf(pad_name, "src_%u", &ch_idx) != 1)
+	{
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Pad name format unexpected: %s", pad_name);
+		goto exit;
+	}
+
+	NAME_ELEMENT(name, "tee", ch_idx);
+	tee = AL_gst_bin_get_by_name(GST_BIN(pipeline), name); 
+	if (!tee) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Tee element not found for %s", name);
+		goto exit;
+	}
+	tee_sink_pad = AL_gst_element_get_static_pad(tee, "sink");
+	if (gst_pad_link(pad, tee_sink_pad) != GST_PAD_LINK_OK) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to link deinterleave %s pad in the rx pipeline",
+						  pad_name);
+	}
+	//fall thru
+exit:
+	dump_pipeline(GST_PIPELINE(pipeline), pad_name);
+	DA_gst_object_unref(tee_sink_pad);
+	DA_gst_object_unref(GST_OBJECT(tee));
+	// setting pipeline state to null here kills audio so just deref the pointer
+	DA_gst_object_unref(GST_OBJECT(pipeline));	
+	DA_g_free(pad_name);						//counted
+done:
+	return;
 }
 
-gboolean update_clock (gpointer userdata) {
-  g_stream_t *stream = (g_stream_t *) userdata;
-  GstStructure *stats = NULL;
-  guint32 rtp_timestamp;
-  GstElement *pipeline;
-  GstClockTime internal, external;
-  gdouble r_sq;
-  GstElement *rtpdepay =NULL;
+gboolean update_clock(gpointer userdata)			//is this a (critical) section
+{
+	g_stream_t *stream = (g_stream_t *)userdata;
 
-  pipeline = (GstElement *) stream->pipeline;
-  rtpdepay = gst_bin_get_by_name (GST_BIN (pipeline), RTP_DEPAY);
+	if (!g_atomic_int_get(&stream->pipeline_active)) {
+		goto done_no_unlock;	// Fast path exit
+	}
 
-  g_object_get (G_OBJECT(rtpdepay), "stats", &stats, NULL);
 
-  if (gst_structure_get_uint(stats, "timestamp", &rtp_timestamp) ) {
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "rtp timestamp in rtpdepay %u\n", rtp_timestamp);
+	GstStructure *stats = NULL;
+	guint32 rtp_timestamp;
+	GstElement *pipeline = NULL;
+	GstClockTime internal, external;
+	gdouble r_sq;
+	GstElement *rtpdepay = NULL;
 
-    internal = gst_clock_get_internal_time(stream->clock);
-    external = gst_util_uint64_scale (rtp_timestamp, GST_SECOND, stream->sample_rate);
+	pipeline = (GstElement *)stream->pipeline;
+	rtpdepay = AL_gst_bin_get_by_name(GST_BIN(pipeline), RTP_DEPAY);
+	if (!rtpdepay) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "rtpdepay not found in pipeline");
+		goto done;
+	}
 
-    if (gst_clock_add_observation(stream->clock, internal, external, &r_sq) &&
-        !g_atomic_int_get (&stream->clock_sync)) {
-      g_atomic_int_set(&stream->clock_sync, 1);
+	g_object_get(G_OBJECT(rtpdepay), "stats", &stats, NULL);		//allocates
 
-      gst_pipeline_use_clock (GST_PIPELINE (pipeline), stream->clock);
-      gst_pipeline_set_clock (GST_PIPELINE (pipeline), stream->clock);
-    }
-  }
+	if (gst_structure_get_uint(stats, "timestamp", &rtp_timestamp)) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "rtp timestamp in rtpdepay %u\n", rtp_timestamp);
 
-  if (stats!=NULL)      gst_structure_free(stats);
-  if (rtpdepay!=NULL)   gst_object_unref (GST_OBJECT(rtpdepay));
+		internal = gst_clock_get_internal_time(stream->clock);
+		external = gst_util_uint64_scale(rtp_timestamp, GST_SECOND, stream->sample_rate);
 
-  return G_SOURCE_CONTINUE;
+		if (gst_clock_add_observation(stream->clock, internal, external, &r_sq) &&
+			!g_atomic_int_get(&stream->clock_sync)) {
+			g_atomic_int_set(&stream->clock_sync, 1);
+
+			gst_pipeline_use_clock(GST_PIPELINE(pipeline), stream->clock);
+			gst_pipeline_set_clock(GST_PIPELINE(pipeline), stream->clock);
+		}
+	}
+
+	DA_gst_structure_free(stats);
+	DA_gst_object_unref(GST_OBJECT(rtpdepay));
+done:
+done_no_unlock:
+	return G_SOURCE_CONTINUE;
 }
 
 /*
@@ -224,118 +251,167 @@ gboolean update_clock (gpointer userdata) {
 
 */
 
-gboolean
-add_appsink (g_stream_t *stream, guint ch_idx, gchar *session)
+gboolean add_appsink(g_stream_t *stream, guint ch_idx, gchar *session)
 {
-  gchar name[ELEMENT_NAME_SIZE];
-  gchar dot_name[ELEMENT_NAME_SIZE+10];
+	gboolean ret = FALSE;
 
-  GstPad* tee_src_pad = NULL;
-  GstPad* queue_sink_pad = NULL;
-  GstElement* tee = NULL;
-  GstElement* queue = NULL;
-  GstElement* appsink = NULL;
+	// Also check atomic flag
+	if (!g_atomic_int_get(&stream->pipeline_active)) {
+		goto done_no_unlock;
+	
+	}
+	gchar name[ELEMENT_NAME_SIZE];
+	gchar dot_name[ELEMENT_NAME_SIZE + 10];
 
-  gboolean ret = FALSE;
+	GstPad *tee_src_pad = NULL;
+	GstPad *queue_sink_pad = NULL;
+	GstElement *tee = NULL;
+	GstElement *queue = NULL;
+	GstElement *appsink = NULL;
 
-  NAME_ELEMENT(name, "tee", ch_idx);
-  tee = gst_bin_get_by_name (GST_BIN(stream->pipeline), name);
-  if (tee == NULL) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to get %s element in the pipeline\n", name);
-    goto error;
-  }
 
-  NAME_SESSION_ELEMENT(name, "queue", ch_idx, session);
-  if (NULL != (queue = gst_bin_get_by_name(GST_BIN (stream->pipeline), name))) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE,
-        "%s already exists in the pipeline ch: %d, session %s", name, ch_idx, session);
-    goto error;
-  }
+	if (!stream || ch_idx >= MAX_IO_CHANNELS) goto error; //added check
+
+	NAME_ELEMENT(name, "tee", ch_idx);
+
+	GRecMutex *ch_mutex = &stream->appsrc_mutexes[ch_idx];
+	g_rec_mutex_lock(ch_mutex); 
+	tee = AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), name);	
+	g_rec_mutex_unlock(ch_mutex); 
+
+	if (!tee ) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to get %s element in the pipeline\n", name);
+		goto error;
+	}
+
+	g_rec_mutex_lock(ch_mutex);
+
+	NAME_SESSION_ELEMENT(name, "queue", ch_idx, session);
+	queue =  AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), name);
+
+	if (queue) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "%s already exists in the pipeline ch: %d, session %s",
+						  name, ch_idx, session);
+		DA_gst_object_unref(GST_OBJECT(queue));
+		queue = NULL;
+		g_rec_mutex_unlock(ch_mutex);
+		goto error;
+	}
+
+
 #ifndef ENABLE_THREADSHARE
-      queue = gst_element_factory_make ("queue", name);
+	queue = AL_gst_element_factory_make("queue", name);
 #else
-      MAKE_TS_ELEMENT(queue, "ts-queue", name, stream->ts_ctx);
+	MAKE_TS_ELEMENT(queue, "ts-queue", name, stream->ts_ctx);
 #endif
+	NAME_SESSION_ELEMENT(name, "appsink", ch_idx, session);
+	appsink = AL_gst_element_factory_make("appsink", name);
+	g_rec_mutex_unlock(ch_mutex);
 
-  NAME_SESSION_ELEMENT(name, "appsink", ch_idx, session);
-  appsink = gst_element_factory_make ("appsink", name);
+	if (!queue || !appsink) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "Failed to create appsink or queue element for ch: %d, session %s", ch_idx, session);
+		goto error;
+	}
+	//check if pipeline is still active
+	if (!g_atomic_int_get(&stream->pipeline_active)) {
+		// Clean up all allocated objects
+		DA_gst_object_unref(GST_OBJECT(tee_src_pad));
+		DA_gst_object_unref(queue_sink_pad);
+		DA_gst_object_unref(GST_OBJECT(appsink));
+		DA_gst_object_unref(GST_OBJECT(queue));
+		DA_gst_object_unref(GST_OBJECT(tee));
+		goto done_no_unlock;
+	}
 
-  if (!queue || !appsink ) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to create appsink or queue element for ch: %d, session %s", ch_idx, session);
-    goto error;
-  }
+	g_rec_mutex_lock(ch_mutex);
+	g_object_set(appsink, "emit-signals", FALSE, "sync", FALSE, "async", FALSE, "drop", TRUE, "max-buffers", 1,
+				 "enable-last-sample", FALSE, NULL);
 
-  g_object_set (appsink, "emit-signals", FALSE, "sync", FALSE, "async", FALSE,
-      "drop", TRUE, "max-buffers", 1, "enable-last-sample", FALSE, NULL);
+	gboolean retval = gst_bin_add(GST_BIN(stream->pipeline), appsink);
+	g_rec_mutex_unlock(ch_mutex);
 
-  if (!gst_bin_add(GST_BIN(stream->pipeline), appsink)) {
-	  switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-			"Failed to add appsink to the pipeline ch: %d, session: %s", ch_idx, session);
-    goto error;
-  }
+	if (!retval) {
+		DA_gst_object_unref(appsink);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "Failed to add appsink to the pipeline ch: %d, session: %s", ch_idx, session);
+		goto error;
+	}
 
-  if(!gst_bin_add(GST_BIN(stream->pipeline), queue)) {
-	  switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-			"Failed to add queue to the pipeline ch: %d, session: %s", ch_idx, session);
-    goto error;
-  }
+	g_rec_mutex_lock(ch_mutex);
+	retval = gst_bin_add(GST_BIN(stream->pipeline), queue);
+	g_rec_mutex_unlock(ch_mutex);
 
-  if (!gst_element_link(queue, appsink)) {
-	  switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-						"Failed to link appsink and queue ch: %d, session: %s", ch_idx, session);
-    goto error;
-  }
+	if (!retval) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "Failed to add queue to the pipeline ch: %d, session: %s", ch_idx, session);
+		goto error;
+	}
 
-  if (NULL == (tee_src_pad = gst_element_request_pad_simple (tee, "src_%u"))) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to get src pad from the tee element ch: %d, session: %s", ch_idx, session);
-    goto error;
-  }
+	if (!gst_element_link(queue, appsink)) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to link appsink and queue ch: %d, session: %s",
+						  ch_idx, session);
+		goto error;
+	}
+	// Both queue and appsink were successfully added to pipeline
+	// These were allocated via AL_ wrappers, so increment counter:
+	g_atomic_int_add(&stream->pipeline_elements_count, 2);
 
-  if (NULL == (queue_sink_pad = gst_element_get_static_pad (queue, "sink"))) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to get sink pad from the queue element ch: %d, session: %s", ch_idx, session);
-    goto error;
-  }
+	if (!(tee_src_pad = AL_gst_element_request_pad_simple(tee, "src_%u"))) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "Failed to get src pad from the tee element ch: %d, session: %s", ch_idx, session);
+		goto error;
+	}
 
-  if (!gst_element_sync_state_with_parent (queue)) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to sync queue state with pipeline. ch: %d, session: %s", ch_idx, session);
-    goto error;
-  }
+	if (!(queue_sink_pad = AL_gst_element_get_static_pad(queue, "sink"))) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "Failed to get sink pad from the queue element ch: %d, session: %s", ch_idx, session);
+		goto error;
+	}
 
-  if (!gst_element_sync_state_with_parent(appsink)) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to sync appsink state with pipeline. ch: %d, session: %s", ch_idx, session);
-    goto error;
-  }
+	if (!gst_element_sync_state_with_parent(queue)) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "Failed to sync queue state with pipeline. ch: %d, session: %s", ch_idx, session);
+		goto error;
+	}
 
-  if (GST_PAD_LINK_OK != (gst_pad_link(tee_src_pad, queue_sink_pad))) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to link the queue and tee. ch: %d, session: %s", ch_idx, session);
-    goto error;
-  }
+	if (!gst_element_sync_state_with_parent(appsink)) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "Failed to sync appsink state with pipeline. ch: %d, session: %s", ch_idx, session);
+		goto error;
+	}
 
-  g_snprintf(dot_name, ELEMENT_NAME_SIZE+10, "%s-add", name);
-  dump_pipeline(GST_PIPELINE(stream->pipeline), dot_name);
+	if (GST_PAD_LINK_OK != (gst_pad_link(tee_src_pad, queue_sink_pad))) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to link the queue and tee. ch: %d, session: %s",
+						  ch_idx, session);
+		goto error;
+	}
 
-  ret = TRUE;
-  goto exit;
+	g_snprintf(dot_name, ELEMENT_NAME_SIZE + 10, "%s-add", name);
+	dump_pipeline(GST_PIPELINE(stream->pipeline), dot_name);
+
+// fall thru
+	ret = TRUE;
+
+	DA_gst_object_unref(GST_OBJECT(tee_src_pad));
+	DA_gst_object_unref(queue_sink_pad);
+	//  accounting
 
 
-error:
-	if (NULL != appsink) gst_object_unref(GST_OBJECT(appsink));
-	if (NULL != queue) gst_object_unref(GST_OBJECT(queue));
-	if (NULL != tee) gst_object_unref(GST_OBJECT(tee));
+	DA_NoNulling_dec_objs(GST_OBJECT(tee)); 
+	DA_NoNulling_dec_objs(GST_OBJECT(queue));
+	DA_NoNulling_dec_objs(GST_OBJECT(appsink));
+	return ret;
 
-exit:
-	if (NULL != tee_src_pad) gst_object_unref(tee_src_pad);
-	if (NULL != queue_sink_pad) gst_object_unref(queue_sink_pad);
-
-    return ret;
-  }
+error: 
+	DA_gst_object_unref(tee_src_pad); 
+	DA_gst_object_unref(queue_sink_pad);
+	DA_gst_object_unref(GST_OBJECT(appsink));			//check
+	DA_gst_object_unref(GST_OBJECT(queue));
+	DA_gst_object_unref(GST_OBJECT(tee));
+done_no_unlock:
+	return ret;
+}
 
 /*
   Unlinks a session's associated queue and appsink from the tee and removes them
@@ -347,871 +423,1222 @@ exit:
 
 */
 
-gboolean
-remove_appsink(g_stream_t *stream, guint ch_idx, gchar *session) {
-  gchar name[ELEMENT_NAME_SIZE];
-  gchar dot_name[ELEMENT_NAME_SIZE + 10];
-
-  GstElement *queue = NULL;
-  GstElement *appsink = NULL;
-  GstElement *tee = NULL;
-  GstPad *tee_src_pad = NULL;
-  GstPad *queue_sink_pad = NULL;
-
-  gboolean ret = FALSE;
-
-  /*
-   * tee -> queue -> appsink
-   *
-   * We unlink the tee and queue first and then remove the queue and
-   * appsink.
-   */
-  NAME_SESSION_ELEMENT(name, "queue", ch_idx, session);
-  queue = gst_bin_get_by_name (GST_BIN (stream->pipeline), name);
-  if (queue == NULL ) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to find %s in the pipeline\n", name);
-    goto error;
-  }
-
-  NAME_ELEMENT(name, "tee", ch_idx);
-  tee = gst_bin_get_by_name (GST_BIN (stream->pipeline), name);
-  if (tee == NULL ) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to find %s in the pipeline\n", name);
-    goto error;
-  }
-
-  if (NULL == (queue_sink_pad = gst_element_get_static_pad (queue, "sink"))) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to get sink pad from the queue element ch: %d, session: %s", ch_idx, session);
-    goto error;
-  }
-
-  if (NULL == (tee_src_pad = gst_pad_get_peer (queue_sink_pad))) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to get src pad from the tee element ch: %d, session: %s", ch_idx, session);
-    goto error;
-  }
-
-  if (!gst_pad_unlink(tee_src_pad, queue_sink_pad)) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to unlink tee and queue ch: %d, session: %s", ch_idx, session);
-  }
-  gst_element_release_request_pad (tee, tee_src_pad);
-
-  gst_object_unref(tee_src_pad);
-  tee_src_pad = NULL;
-
-  gst_object_unref(queue_sink_pad);
-  queue_sink_pad = NULL;
-
-  NAME_SESSION_ELEMENT(name, "appsink", ch_idx, session);
-  appsink = gst_bin_get_by_name (GST_BIN (stream->pipeline), name);
-  if (appsink == NULL ) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to find %s in the pipeline\n", name);
-    goto error;
-  }
-
-  gst_element_unlink(queue, appsink);
-
-  if (!gst_bin_remove(GST_BIN(stream->pipeline), queue)) {
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to remove queue from the pipeline ch: %d, session: %s", ch_idx, session);
-  }
-
-  if (!gst_bin_remove(GST_BIN(stream->pipeline), appsink)) {
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to remove appsink from the pipeline ch: %d, session: %s", ch_idx, session);
-  }
-
-  gst_element_set_state(queue, GST_STATE_NULL);
-  gst_element_set_state(appsink, GST_STATE_NULL);
-
-  g_snprintf(dot_name, ELEMENT_NAME_SIZE+10, "%s-del", name);
-  dump_pipeline(GST_PIPELINE(stream->pipeline), dot_name);
-
-  ret = TRUE;
-
-exit:
-  ret = TRUE;
-error:
-  if (NULL != tee_src_pad)	gst_object_unref(GST_OBJECT(tee_src_pad));
-  if (NULL != queue_sink_pad)	gst_object_unref(GST_OBJECT(queue_sink_pad));
-  if (NULL != appsink)	gst_object_unref(GST_OBJECT(appsink));
-  if (NULL != queue)	gst_object_unref(GST_OBJECT(queue));
-  if (NULL != tee)	gst_object_unref(GST_OBJECT(tee));
-
-  return ret;
-}
-
-static gboolean
-backup_sender_timeout_cb(gpointer userdata)
+gboolean remove_appsink(g_stream_t *stream, guint ch_idx, gchar *session)
 {
-  gboolean ret = TRUE;
-  g_stream_t* stream = (g_stream_t *)userdata;
-  GstElement* fakesink =  gst_bin_get_by_name (GST_BIN (stream->pipeline), "tx-monitor-fakesink");
-  GstClock* clock = NULL;
-  GstBuffer* buffer = NULL;
-  GstSample* last_sample = NULL;
-  GstNetAddressMeta* meta = NULL;
+	gboolean ret = FALSE;
+	GstElement *queue = NULL;
+	GstElement *appsink = NULL;
+	GstElement *tee = NULL;
+	GstPad *tee_src_pad = NULL;
+	GstPad *queue_sink_pad = NULL;
 
-  GSocketAddress *sock_addr = NULL;
-  
-  gchar *host = NULL;
- 
-  if (fakesink) {
-    clock = gst_element_get_clock (fakesink);
-
-    if (clock) {
-      //pipeline in PLAYING state
-      GstClockTime current_time = gst_clock_get_time(clock);
-	    GstClockTime delta;
-      GstBuffer *buffer = NULL;
-      GstClockTime timestamp;
-      GstSample *last_sample = NULL;
-      GstNetAddressMeta *meta;
-      GSocketAddress * sock_addr;
-      gchar *host;
-      GstClockTime max_delta = stream->backup_sender_idle_wait_ms * GST_MSECOND;
-
-      g_object_get(G_OBJECT(fakesink), "last-sample", &last_sample, NULL);
-
-      if (!last_sample) 
-		  goto exit;
-
-      // no memory allocated
-      buffer = gst_sample_get_buffer(last_sample); 
-      timestamp = GST_BUFFER_DTS_OR_PTS (buffer);
-      meta = gst_buffer_get_net_address_meta(buffer); 
-      //
-
-      sock_addr = meta->addr;
-      host = g_inet_address_to_string (g_inet_socket_address_get_address    //allocates memory!!
-            (G_INET_SOCKET_ADDRESS (sock_addr)));
-
-      /* If the buffer timestamp is after the previous callback or before the next callback
-        we know that new buffers are arriving and so pause our Tx */
-      delta = timestamp < current_time ? current_time - timestamp : timestamp - current_time;
-
-      if (delta < max_delta && FALSE == stream->pause_backup_sender) {
-        stream->pause_backup_sender = TRUE;
-
-        drop_output_buffers(TRUE, stream);
-        switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE,
-          "got buffer from %s. Paused the backup sender\n", host);
-      } else if (delta >= max_delta && TRUE == stream->pause_backup_sender) {
-        stream->pause_backup_sender = FALSE;
-
-        switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE,
-          "Time since last-sample from %s - %"GST_TIME_FORMAT". Resuming the backup sender\n", host, GST_TIME_ARGS(delta));
-
-        // Stop dropping Tx buffers only if the if 'txdrop' is FALSE,
-        // in other words if 'txflow' is set to ON by the user
-        if (FALSE == stream->txdrop)
-          drop_output_buffers(FALSE, stream);
-        else
-          switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "txflow is off, continuing to drop the buffers\n");
-	    } else {
-        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "got last-sample from %s\n", host);
-        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "delta - %"GST_TIME_FORMAT"; current time - %"GST_TIME_FORMAT"; last-sample timestamp - %"GST_TIME_FORMAT"\n", GST_TIME_ARGS(delta), GST_TIME_ARGS(current_time), GST_TIME_ARGS(timestamp));
-      }
-
-      gst_sample_unref(last_sample);
-	  last_sample = NULL;
-      gst_object_unref(clock);
-	  clock = NULL;
-    } else {
-      switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-          "Clock not available, pipeline is not PLAYING\n");
-    }
-
-    gst_object_unref (GST_OBJECT (fakesink));
-	fakesink = NULL;
-  } else {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-          "Could not find fakesink the stream\n");
-  }
-
-exit:
-	if (last_sample!=NULL) gst_sample_unref(last_sample);
-	if (clock!=NULL) gst_object_unref(GST_OBJECT(clock));
-	if (fakesink != NULL) gst_object_unref(GST_OBJECT(fakesink));
-    if (host != NULL) g_free(host);
-
-    return ret;
-}
-
-
-g_stream_t *
-create_pipeline (pipeline_data_t *data, event_callback_t * error_cb)
-{
-  GstBus *bus = NULL;
-  GstElement *pipeline = NULL;
-  GstElement *rtp_pay = NULL;
-  GstElement *rtpdepay = NULL;
-  GstElement *rtpjitbuf = NULL;
-  char *pipeline_name;
-
-  g_stream_t *stream = g_new (g_stream_t, 1);
-
-  char fixed_name[25] = { "pipeline" };
-  char *ts_ctx = DEFAULT_CONTEXT_NAME;
-
-  if (data->name)
-    pipeline_name = data->name;
-  else
-    pipeline_name = fixed_name;
-
-  if (0 != strlen(data->ts_context_name))
-    ts_ctx = data->ts_context_name;
-
-  stream->ts_ctx = ts_ctx;
-  pipeline = gst_pipeline_new (pipeline_name);          //allocates memory!
-  if (!pipeline) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,"Failed to create the pipeline\n");
-	goto error;
-  }
-
-  if (data->direction & DIRECTION_RX) {
-	  GstElement *udp_source=NULL;
-	  GstElement *deinterleave = NULL;
-	  GstElement *rx_audioconv = NULL;
-	  GstElement *capsfilter = NULL;
-	  GstElement *split = NULL;
-	  GstElement *tee = NULL;
-
-	  GstCaps *udp_caps = NULL;
-	  GstCaps *rx_caps = NULL;
-
-#ifndef ENABLE_THREADSHARE
-    udp_source = gst_element_factory_make ("udpsrc", "rx-src");
-#else
-    MAKE_TS_ELEMENT(udp_source, "ts-udpsrc", "rx-src", ts_ctx);
-#endif
-    g_object_set(udp_source, "buffer-size", 1048576, NULL);
-
-    if (data->rx_codec == L16) {
-      rtpdepay = gst_element_factory_make ("rtpL16depay", RTP_DEPAY);
-      udp_caps = gst_caps_new_simple ("application/x-rtp",
-          "clock-rate", G_TYPE_INT, data->sample_rate,
-          "channels", G_TYPE_INT, data->channels,
-          "channel-order", G_TYPE_STRING, "unpositioned",
-          "encoding-name", G_TYPE_STRING, "L16",
-          "media", G_TYPE_STRING, "audio", NULL);
-    } else {
-      rtpdepay = gst_element_factory_make ("rtpL24depay", RTP_DEPAY);
-      udp_caps = gst_caps_new_simple ("application/x-rtp",
-          "clock-rate", G_TYPE_INT, data->sample_rate,
-          "channels", G_TYPE_INT, data->channels,
-          "channel-order", G_TYPE_STRING, "unpositioned",
-          "encoding-name", G_TYPE_STRING, "L24",
-          "media", G_TYPE_STRING, "audio", NULL);
-    }
-
-    rtpjitbuf = gst_element_factory_make("rtpjitterbuffer", "rx-jitbuf");
-    g_signal_connect_data(rtpjitbuf, "request-pt-map", G_CALLBACK(request_pt_map),
-        gst_caps_ref(udp_caps), destroy_caps, 0);
-
-    g_object_set(rtpjitbuf, "latency", data->rtp_jitbuf_latency,
-        "mode", 0 /* none */,
-        NULL);
-    rx_audioconv = gst_element_factory_make ("audioconvert", "rx-aconv");
-    g_object_set(rx_audioconv, "dithering", 0 /* none */, NULL);
-
-    capsfilter = gst_element_factory_make ("capsfilter", "rx-caps");
-
-    /*Always feed S16LE to the FS*/
-    rx_caps = gst_caps_new_simple ("audio/x-raw",
-        "channels", G_TYPE_INT, data->channels,
-        "format", G_TYPE_STRING, "S16LE",
-        "layout", G_TYPE_STRING, "interleaved", NULL);
-
-    g_object_set (capsfilter, "caps", rx_caps, NULL);
-	gst_caps_unref(rx_caps);
-	rx_caps = NULL;
-
-    split = gst_element_factory_make ("audiobuffersplit", "rx-split");
-    g_object_set (split, "output-buffer-duration", data->codec_ms, 1000, NULL);
-
-    deinterleave = gst_element_factory_make ("deinterleave", "rx-deinterleave");
-
-    for (guint ch = 0; ch < data->channels; ch++) {
-      gchar name[ELEMENT_NAME_SIZE];
-
-      NAME_ELEMENT(name, "tee", ch);
-      tee = gst_element_factory_make ("tee", name);
-
-      if (!tee) {
-        switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to create tee element in rx pipeline\n");
-        continue;
-      }
-      g_object_set(tee, "allow-not-linked", TRUE, NULL);
-
-      gst_bin_add (GST_BIN(pipeline), tee);
-      // The deinterleave will be linked to the tee dynamically
-    }
-
-    g_signal_connect (deinterleave, "pad-added",
-        G_CALLBACK (deinterleave_pad_added), NULL);
-
-    g_object_set (udp_source, "address", data->rx_ip_addr, "port", data->rx_port,
-        "multicast-iface", data->rtp_iface,
-        "retrieve-sender-address", FALSE,
-        NULL);
-    g_object_set (udp_source, "caps", udp_caps, NULL);
-	gst_caps_unref(udp_caps);
-	udp_caps = NULL;
-
-    if (!udp_source || !rtpdepay || !rtpjitbuf || !rx_audioconv || !capsfilter
-        || !split || !deinterleave) {
-      switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-          "Failed to create rx elements\n");
- 	goto ddirRX_error;
+	if (!stream || ch_idx >= MAX_IO_CHANNELS) goto exit; // added check
+	if (!g_atomic_int_get(&stream->pipeline_active)) { 
+		goto done_no_unlock; 
 	}
 
-    gst_bin_add_many (GST_BIN (pipeline), udp_source, rtpdepay, rtpjitbuf, rx_audioconv,
-        capsfilter, split, deinterleave, NULL);
-
-    if (!gst_element_link_many (udp_source, rtpjitbuf, rtpdepay, split, rx_audioconv, capsfilter,
-            deinterleave, NULL)) {
-      switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-          "Failed to link elements in the rx pipeline");
-      goto ddirRX_error;
-    }
-	
-    goto ddirRX_exit;
-
-ddirRX_error:
-	if (udp_source != NULL)   gst_object_unref(GST_OBJECT(udp_source));
-	if (deinterleave != NULL) gst_object_unref(GST_OBJECT(deinterleave));
-	if (rx_audioconv != NULL) gst_object_unref(GST_OBJECT(rx_audioconv));
-	if (capsfilter != NULL)   gst_object_unref(GST_OBJECT(capsfilter));
-	if (tee != NULL)          gst_object_unref(GST_OBJECT(tee));
-	if (split != NULL)        gst_object_unref(GST_OBJECT(split));
-    goto error;
-	
-ddirRX_exit:;
-  }
+	gchar name[ELEMENT_NAME_SIZE];
+	gchar dot_name[ELEMENT_NAME_SIZE + 10];
 
 
-  if (data->direction & DIRECTION_TX) {
-    GstElement *udpsink=NULL;
-	GstElement *tx_audioconv = NULL;
-	GstElement *audiointerleave = NULL;
-	GstElement *capsfilter = NULL;
-	GstElement *tx_valve = NULL	;
-    GstElement *appsrc = NULL;
-    GstCaps *caps = NULL;
 
-    audiointerleave = gst_element_factory_make ("audiointerleave", "audiointerleave"); //allocates memory!
-    gst_bin_add (GST_BIN (pipeline), audiointerleave);
-    g_object_set(audiointerleave, "start-time-selection", GST_AGGREGATOR_START_TIME_SELECTION_FIRST, NULL);
-    g_object_set(audiointerleave, "output-buffer-duration", data->codec_ms * GST_MSECOND, NULL);
+	/*
+	 * tee -> queue -> appsink
+	 *
+	 * We unlink the tee and queue first and then remove the queue and
+	 * appsink.
+	 */
 
-    if (data->tx_codec == L16) {
-      rtp_pay = gst_element_factory_make ("rtpL16pay", "rtp-pay");
+	GRecMutex *ch_mutex = &stream->appsrc_mutexes[ch_idx];
+	g_rec_mutex_lock(ch_mutex); 
 
-    } else {
-      rtp_pay = gst_element_factory_make ("rtpL24pay", "rtp-pay");
-    }
-    g_object_set(rtp_pay, "pt", data->rtp_payload_type, NULL);
+	NAME_SESSION_ELEMENT(name, "queue", ch_idx, session);
+	queue = AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), name);
+	g_rec_mutex_unlock(ch_mutex);
 
-    if (data->ptime_ms != -1.0) {
-      g_object_set(rtp_pay, "max-ptime", (gint64) (data->ptime_ms * 1000000),
-          "min-ptime", (gint64) (data->ptime_ms * 1000000), NULL);
-    }
+	if (!queue ) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to find %s in the pipeline\n", name);
+		goto exit;
+	}
 
-    for (guint ch = 0; ch < data->channels; ch++) {
-      gchar name[ELEMENT_NAME_SIZE];
-      gchar pad_name[STR_SIZE];
+	g_rec_mutex_lock(ch_mutex);
+	NAME_ELEMENT(name, "tee", ch_idx);
+	tee = AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), name);		//tees deallocated by pipline
+	g_rec_mutex_unlock(ch_mutex);
 
-      NAME_ELEMENT (name, "appsrc", ch);
-      g_snprintf (pad_name, STR_SIZE, "sink_%u", ch);
+	if (!tee ) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to find %s in the pipeline\n", name);
+		goto exit;
+	}
 
-      appsrc = gst_element_factory_make ("appsrc", name);
-      if (!appsrc) {
-        switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to create %s \n", name);
-        continue;
-      }
+	g_rec_mutex_lock(ch_mutex);
+	if (!(queue_sink_pad = AL_gst_element_get_static_pad(queue, "sink"))) {
+		g_rec_mutex_unlock(ch_mutex);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "Failed to get sink pad from the queue element ch: %d, session: %s", ch_idx, session);
+		goto exit;
+	}
 
-      /*Always accept S16LE from the FS*/
-      caps = gst_caps_new_simple ("audio/x-raw",
-          "rate", G_TYPE_INT, data->sample_rate,
-          "channels", G_TYPE_INT, 1,
-          "format", G_TYPE_STRING, "S16LE",
-          "layout", G_TYPE_STRING, "interleaved",
-          "channel-mask", GST_TYPE_BITMASK, (guint64) 0, NULL);
-      g_object_set (appsrc, "format", GST_FORMAT_TIME, NULL);
-      g_object_set (appsrc, "do-timestamp", TRUE, NULL);
-      g_object_set (appsrc, "is-live", TRUE, NULL);
-      /* Second * 3 allows a little bit of headroom */
-      g_object_set (appsrc, "max-bytes", data->codec_ms * data->sample_rate * 2 * 3 / 1000,  NULL);
-
-      g_object_set (appsrc, "caps", caps, NULL);
-	  gst_caps_unref(caps);
-	  caps = NULL;
-      gst_bin_add (GST_BIN (pipeline), appsrc);
-
-      if (!gst_element_link_pads (appsrc, "src", audiointerleave, pad_name)) {
-        switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-            "Failed to link pads of %s with audiointerleave\n", name);
-        goto ddirTX_error;
-
-      }
-    }
-
-    tx_valve = gst_element_factory_make ("valve", "tx-valve");
-    g_object_set (tx_valve, "drop", data->txdrop, NULL);
-
-    capsfilter = gst_element_factory_make ("capsfilter", "tx-capsf");
-
-    tx_audioconv = gst_element_factory_make ("audioconvert", "tx-audioconv");
-    g_object_set(tx_audioconv, "dithering", 0 /* none */, NULL);
-
-    udpsink = gst_element_factory_make ("udpsink", "tx-sink");
-
-    caps = gst_caps_new_simple ("audio/x-raw",
-        "rate", G_TYPE_INT, data->sample_rate,
-        "channels", G_TYPE_INT, data->channels,
-        "format", G_TYPE_STRING, "S16LE",
-        "layout", G_TYPE_STRING, "interleaved",
-        "channel-mask", GST_TYPE_BITMASK, (guint64) 0,
-        NULL);
-    g_object_set (capsfilter, "caps", caps, NULL);
-	gst_caps_unref(caps);
-	caps = NULL;
-
-    g_object_set (udpsink, "host", data->tx_ip_addr, "port", data->tx_port, "multicast-iface", data->rtp_iface, NULL);
-    g_object_set (udpsink, "sync", TRUE, "async", FALSE, NULL);
-    g_object_set (udpsink, "qos", TRUE, "qos-dscp", 34, NULL);
-    g_object_set (udpsink, "processing-deadline", 0 * GST_MSECOND, NULL);
-    if (data->is_backup_sender) {
-#ifndef _WIN32
-      // Disable IP_MULTICAST_LOOP to avoid listening packets from same host
-      // For Linux this needs to be set on the sender's side
-      g_object_set(udpsink, "loop", FALSE, NULL);
-#endif
-    }
-
-    if (!audiointerleave || !tx_valve || !tx_audioconv || !rtp_pay || !udpsink) {
-      switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-          "Failed to create tx elements\n");
-	goto ddirTX_error;
-    }
-
-    gst_bin_add_many (GST_BIN (pipeline), tx_valve, capsfilter, tx_audioconv, rtp_pay,
-        udpsink, NULL);
-
-    if (!gst_element_link_many (audiointerleave, tx_valve, capsfilter, tx_audioconv,
-            rtp_pay, udpsink, NULL)) {
-      switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-          "Failed to link elements");
-		goto ddirTX_error;
-    }
-
-	goto ddirTX_exit;
-
-ddirTX_error:
-	  if (udpsink != NULL) gst_object_unref(GST_OBJECT(udpsink));
-      if (tx_audioconv != NULL) gst_object_unref(GST_OBJECT(tx_audioconv));
-	  if (audiointerleave != NULL) gst_object_unref(GST_OBJECT(audiointerleave));
-	  if (capsfilter != NULL) gst_object_unref(GST_OBJECT(capsfilter));
-	  if (tx_valve != NULL) gst_object_unref(GST_OBJECT(tx_valve));
-	  if (appsrc != NULL) gst_object_unref(GST_OBJECT(appsrc));
-	  goto error;
+	if (!(tee_src_pad = AL_gst_pad_get_peer(queue_sink_pad))) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "Failed to get src pad from the tee element ch: %d, session: %s", ch_idx, session);
+		g_rec_mutex_unlock(ch_mutex);
+		goto exit;
+	}
+	g_rec_mutex_unlock(ch_mutex);
 
 
-  ddirTX_exit:;
-  }
+	if (!gst_pad_unlink(tee_src_pad, queue_sink_pad)) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to unlink tee and queue ch: %d, session: %s",
+						  ch_idx, session);
+	}
 
-  /* if this stream is configured to be a backup sender, we pause our Tx if we find another sender doing Tx
-    on the same multicast address and resume once the remote sender stops
-  */
-  if (data->is_backup_sender) {
-	  GstElement *udpsrc = NULL;
-	  GstElement *fakesink = NULL;
-	  GstCaps *caps = NULL;
-	  
+	// Drain pending samples from appsink BEFORE bin_remove to avoid races
+	GstSample *sample = NULL;
+	GstClockTime timeout = 100 * GST_MSECOND; // 100ms total drain window
 
-  /* create a dummy pipeline with `udpsrc ! fakesink` just to receive on udp and read the last-sample from fakesink */
+	g_rec_mutex_lock(ch_mutex);
+	NAME_SESSION_ELEMENT(name, appsink, ch_idx, session);
+	appsink = gst_bin_get_by_name(GST_BIN(stream->pipeline), name);
+
+
+	if (appsink) {
+		gst_element_send_event(appsink, gst_event_new_flush_start());
+		gst_element_send_event(appsink, gst_event_new_flush_stop(TRUE));
+		while (!gst_app_sink_is_eos(GST_APP_SINK(appsink))) {
+			sample = gst_app_sink_try_pull_sample(GST_APP_SINK(appsink), timeout);
+			if (sample) {
+				DA_gst_sample_unref(sample);
+				sample = NULL;
+			} else {
+				break; // No more samples or timeout
+			}
+		}
+		// Force appsink to NULL state safely
+		gst_element_set_state(appsink, GST_STATE_NULL);
+		DA_gst_object_unref(appsink);
+		appsink = NULL;
+	}
+
+
+	gst_element_release_request_pad(tee, tee_src_pad);
+
+	NAME_SESSION_ELEMENT(name, "appsink", ch_idx, session);
+	appsink = AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), name);
+	g_rec_mutex_unlock(ch_mutex);
+
+	if (!appsink ) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to find %s in the pipeline\n", name);
+		goto exit;
+	}
+
+	gst_element_unlink(queue, appsink);
+	g_rec_mutex_lock(ch_mutex);
+	if (!gst_bin_remove(GST_BIN(stream->pipeline), queue)) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+        "Failed to remove queue from the pipeline ch: %d, session: %s", ch_idx, session);
+	}
+	g_rec_mutex_unlock(ch_mutex);
+
+	if (queue) 
+		gst_element_set_state(queue, GST_STATE_NULL);
+	if (appsink) 
+		gst_element_set_state(appsink, GST_STATE_NULL);
+
+
+	g_rec_mutex_lock(ch_mutex);
+	if (!gst_bin_remove(GST_BIN(stream->pipeline), appsink)) { // non fatal //check mutex
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "Failed to remove appsink from the pipeline ch: %d, session: %s", ch_idx, session);
+	}
+	g_rec_mutex_unlock(ch_mutex);		
+
+	// Both queue and appsink were removed from pipeline (even if one failed, attempt was made)
+	// Decrement the counter to match the increments in add_appsink():
+	g_atomic_int_add(&stream->pipeline_elements_count, -2);
+
+	g_snprintf(dot_name, ELEMENT_NAME_SIZE + 10, "%s-del", name);
+	dump_pipeline(GST_PIPELINE(stream->pipeline), dot_name);			//for info only
+
+	ret = TRUE;
+
+exit:
+	DA_gst_object_unref(tee_src_pad);
+	DA_gst_object_unref(queue_sink_pad);
+	DA_gst_object_unref(GST_OBJECT(appsink));
+	DA_gst_object_unref(GST_OBJECT(queue));
+	DA_gst_object_unref(GST_OBJECT(tee));
+done_no_unlock:
+	return ret;
+}
+
+static gboolean backup_sender_timeout_cb(gpointer userdata)
+{
+	gboolean retval = TRUE;
+	g_stream_t *stream = (g_stream_t *)userdata;
+
+    if (!g_atomic_int_get(&stream->pipeline_active)) {
+		retval = G_SOURCE_CONTINUE; // Shutdown in progress
+		goto done_no_unlock;
+		
+	}
+
+	GstElement *fakesink = AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), "tx-monitor-fakesink");
+	GstClock *clock = NULL;
+	GstBuffer *buffer = NULL;
+	GstSample *last_sample = NULL;
+	GstNetAddressMeta *meta = NULL;
+
+	GSocketAddress *sock_addr = NULL;
+	gchar *host = NULL;
+
+	if (fakesink) {
+		clock = AL_gst_element_get_clock(fakesink);
+		if (!clock) {
+			//switch_log_printf(...);
+			DA_gst_object_unref(GST_OBJECT(GST_OBJECT(fakesink))); // added
+			retval = G_SOURCE_CONTINUE;
+	   	    goto done;
+		} 
+
+		if (clock) {
+			// pipeline in PLAYING state
+			GstClockTime current_time = gst_clock_get_time(clock);
+			GstClockTime delta;
+			GstClockTime timestamp;
+
+			GstClockTime max_delta = stream->backup_sender_idle_wait_ms * GST_MSECOND;
+
+			g_object_get(G_OBJECT(fakesink), "last-sample", &last_sample, NULL);	//allocates!
+							
+			if (!last_sample) 
+				goto exit;
+			AL_cnt_samples(last_sample); // accounting
+
+			buffer = gst_sample_get_buffer(last_sample);	//no alloc 
+			timestamp = GST_BUFFER_DTS_OR_PTS(buffer);
+			meta = gst_buffer_get_net_address_meta(buffer);
+			//
+
+			sock_addr = meta->addr;
+			host = g_inet_address_to_string(g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS(sock_addr))); //allocates!
+			/* If the buffer timestamp is after the previous callback or before the next callback
+			  we know that new buffers are arriving and so pause our Tx */
+			delta = timestamp < current_time ? current_time - timestamp : timestamp - current_time;
+			
+
+			if (delta < max_delta && FALSE == stream->pause_backup_sender) {
+				stream->pause_backup_sender = TRUE;
+
+				drop_output_buffers(TRUE, stream);
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE,
+								  "got buffer from %s. Paused the backup sender\n", host);
+			} else if (delta >= max_delta && TRUE == stream->pause_backup_sender) {
+				stream->pause_backup_sender = FALSE;
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE,
+								  "Time since last-sample from %s - %" GST_TIME_FORMAT ". Resuming the backup sender\n",
+								  host, GST_TIME_ARGS(delta));
+
+				// Stop dropping Tx buffers only if the if 'txdrop' is FALSE,
+				// in other words if 'txflow' is set to ON by the user
+				if (FALSE == stream->txdrop)
+					drop_output_buffers(FALSE, stream);
+				else
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE,
+									  "txflow is off, continuing to drop the buffers\n");
+			} else {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "got last-sample from %s\n", host);
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
+								  "delta - %" GST_TIME_FORMAT "; current time - %" GST_TIME_FORMAT
+								  "; last-sample timestamp - %" GST_TIME_FORMAT "\n",
+								  GST_TIME_ARGS(delta), GST_TIME_ARGS(current_time), GST_TIME_ARGS(timestamp));
+			}
+
+
+			DA_gst_sample_unref(last_sample);
+			last_sample = NULL;
+
+			DA_gst_object_unref(GST_OBJECT(clock));
+			clock = NULL;
+
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Clock not available, pipeline is not PLAYING\n");
+		}
+		DA_gst_object_unref(GST_OBJECT(fakesink));
+		fakesink = NULL;
+
+	} else {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not find fakesink the stream\n");
+	}
+
+exit:
+	DA_gst_sample_unref(last_sample);
+	DA_gst_object_unref(GST_OBJECT(clock));
+	DA_gst_object_unref(GST_OBJECT(fakesink));
+	g_free(host);			//not counted
+done:
+done_no_unlock:
+	return retval;
+}
+
+
+
+g_stream_t *create_pipeline(pipeline_data_t *data, event_callback_t *error_cb)
+{
+	GstBus *bus = NULL;
+	GstElement *pipeline = NULL;
+	GstElement *rtp_pay = NULL;
+	GstElement *rtpdepay = NULL;
+	GstElement *rtpjitbuf = NULL;
+	char *pipeline_name = NULL;
+
+	// init entire structure
+	g_stream_t *stream = g_new0(g_stream_t, 1);			
+	// Initialize the counter used for deallocation in stop pipeline
+	g_atomic_int_set(&stream->pipeline_elements_count, 0);
+
+	char fixed_name[25] = {"pipeline"};
+	char *ts_ctx = DEFAULT_CONTEXT_NAME;
+
+	stream->bus_watch_id = gst_bus_add_watch(bus, bus_callback, stream);		//added
+
+	if (data->name)
+		pipeline_name = data->name;
+	else
+		pipeline_name = fixed_name;
+
+	if (0 != strlen(data->ts_context_name)) 
+		ts_ctx = data->ts_context_name;
+
+	stream->ts_ctx = ts_ctx;
+	pipeline = gst_pipeline_new(pipeline_name);		// allocates memory!
+	if (!pipeline) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to create the pipeline\n");
+		goto error;
+	}
+	stream->pipeline_active = 0; // Start inactive
+
+	if (data->direction & DIRECTION_RX) {
+		GstElement *udp_source = NULL;
+		GstElement *deinterleave = NULL;
+		GstElement *rx_audioconv = NULL;
+		GstElement *capsfilter = NULL;
+		GstElement *split = NULL;
+		GstElement *tee = NULL;
+
+		GstCaps *udp_caps = NULL;
+		GstCaps *rx_caps = NULL;
+
 #ifndef ENABLE_THREADSHARE
-    udpsrc = gst_element_factory_make ("udpsrc", "tx-monitor-udpsrc");
+		udp_source = AL_gst_element_factory_make("udpsrc", "rx-src");
 #else
-    MAKE_TS_ELEMENT(udpsrc, "ts-udpsrc", "tx-monitor-udpsrc", ts_ctx);
+		MAKE_TS_ELEMENT(udp_source, "ts-udpsrc", "rx-src", ts_ctx);
+#endif
+		g_object_set(udp_source, "buffer-size", 1048576, NULL);
+
+		if (data->rx_codec == L16) {
+			rtpdepay = AL_gst_element_factory_make("rtpL16depay", RTP_DEPAY);
+			udp_caps = gst_caps_new_simple("application/x-rtp", 
+					"clock-rate", G_TYPE_INT, data->sample_rate, 
+					"channels",	G_TYPE_INT, data->channels, 
+					"channel-order", G_TYPE_STRING, "unpositioned",
+					"encoding-name", G_TYPE_STRING, "L16", 
+					"media", G_TYPE_STRING, "audio", NULL);
+			if (!udp_caps)		{ 
+				goto ddirRX_error;
+			}
+		} else {
+			rtpdepay = AL_gst_element_factory_make("rtpL24depay", RTP_DEPAY);
+			udp_caps =	gst_caps_new_simple("application/x-rtp", 
+			"clock-rate", G_TYPE_INT, data->sample_rate, 
+			"channels",	G_TYPE_INT, data->channels, 
+			"channel-order", G_TYPE_STRING, "unpositioned",
+			"encoding-name", G_TYPE_STRING, "L24", 
+			"media", G_TYPE_STRING, "audio", NULL);
+			if (!udp_caps) { 
+				goto ddirRX_error;
+			}
+		}
+
+		rtpjitbuf = AL_gst_element_factory_make("rtpjitterbuffer", "rx-jitbuf");
+
+		// TODO: remove after testing
+		#ifdef PUTBACKTHISERROR
+		stream->jitterbuf_signal_id = g_signal_connect_data(rtpjitbuf, "request-pt-map", G_CALLBACK(request_pt_map), 
+			gst_caps_ref(udp_caps),  destroy_caps, 0);
+		#endif
+
+		g_object_set(rtpjitbuf, "latency", data->rtp_jitbuf_latency,
+		 "mode", 0 /* none */, 
+		 NULL);
+		rx_audioconv = AL_gst_element_factory_make("audioconvert", "rx-aconv");
+		g_object_set(rx_audioconv, "dithering", 0 /* none */, NULL);
+
+		capsfilter = AL_gst_element_factory_make("capsfilter", "rx-caps");
+
+		/*Always feed S16LE to the FS*/
+		rx_caps = gst_caps_new_simple("audio/x-raw", 
+			"channels", G_TYPE_INT, data->channels, 
+			"format", G_TYPE_STRING, "S16LE",
+			"layout", G_TYPE_STRING, "interleaved",
+			 NULL);
+		if (!rx_caps) { // error
+			DA_gst_caps_unref(udp_caps);
+			udp_caps = NULL;
+			goto ddirRX_error;
+		}
+		g_object_set(capsfilter, "caps", rx_caps, NULL);
+		DA_gst_caps_unref(rx_caps);
+		rx_caps = NULL;
+
+		split = AL_gst_element_factory_make("audiobuffersplit", "rx-split");
+		g_object_set(split, "output-buffer-duration", data->codec_ms, 1000, NULL);
+
+		deinterleave = AL_gst_element_factory_make("deinterleave", "rx-deinterleave");
+
+		for (gint ch = 0; ch < data->channels; ch++) {
+			gchar name[ELEMENT_NAME_SIZE];
+
+			NAME_ELEMENT(name, "tee", ch);
+			tee = gst_element_factory_make("tee", name);		//do not count, since pipeline deallocs
+
+			if (!tee) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+								  "Failed to create tee element in rx pipeline\n");
+				continue;
+			}
+			g_object_set(tee, "allow-not-linked", TRUE, NULL);
+			gst_bin_add(GST_BIN(pipeline), tee);
+			// The deinterleave will be linked to the tee dynamically
+		}
+
+		stream->deinterleave_signal_id =
+			g_signal_connect(deinterleave, "pad-added",
+			G_CALLBACK(deinterleave_pad_added), stream); 
+
+		g_object_set(udp_source, "address", data->rx_ip_addr, "port", data->rx_port, 
+			"multicast-iface", data->rtp_iface,
+			"retrieve-sender-address", FALSE, 
+			NULL);
+		g_object_set(udp_source, "caps", udp_caps, NULL);
+		stream->jitterbuf_signal_id = g_signal_connect_data(rtpjitbuf, "request-pt-map", G_CALLBACK(request_pt_map),
+															udp_caps, // Don't ref here, destroy_caps will handle it
+															destroy_caps, 0);
+
+
+		if (!udp_source || !rtpdepay || !rtpjitbuf || !rx_audioconv || !capsfilter || !split || !deinterleave) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to create rx elements\n");
+			goto ddirRX_error;
+		}
+
+		gst_bin_add_many(GST_BIN(pipeline), udp_source, rtpdepay, rtpjitbuf, rx_audioconv, capsfilter, split, deinterleave, NULL);
+		g_atomic_int_add(&stream->pipeline_elements_count, 7);
+
+		if (!gst_element_link_many(udp_source, rtpjitbuf, rtpdepay, split, rx_audioconv, capsfilter, deinterleave, NULL)) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to link elements in the rx pipeline");
+			goto ddirRX_error;
+		}
+
+
+		goto ddirRX_exit;
+
+	ddirRX_error:
+		DA_gst_caps_unref(udp_caps); 
+		udp_caps = NULL;
+		DA_gst_caps_unref(rx_caps); 
+		rx_caps = NULL;
+		DA_gst_object_unref(GST_OBJECT(udp_source));
+		udp_source = NULL;
+		DA_gst_object_unref(GST_OBJECT(deinterleave));
+		deinterleave = NULL;
+		DA_gst_object_unref(GST_OBJECT(rx_audioconv));
+		rx_audioconv = NULL;
+		DA_gst_object_unref(GST_OBJECT(capsfilter));
+		capsfilter = NULL;
+		tee = NULL;
+		DA_gst_object_unref(GST_OBJECT(split));
+		split = NULL;
+		DA_gst_object_unref(GST_OBJECT(rtpjitbuf));		//added to pipeline
+		rtpjitbuf = NULL;
+		DA_gst_object_unref(GST_OBJECT(rtpdepay));		// added to pipeline
+		rtpdepay = NULL;
+		goto error;
+
+	ddirRX_exit:
+		//  accounting
+		if (udp_source) DA_NoNulling_dec_objs(udp_source); 
+		if (rtpdepay) DA_NoNulling_dec_objs(rtpdepay);
+		if (rtpjitbuf) DA_NoNulling_dec_objs(rtpjitbuf);
+		if (rx_audioconv) DA_NoNulling_dec_objs(rx_audioconv);
+		if (capsfilter) DA_NoNulling_dec_objs(capsfilter);
+		if (split) DA_NoNulling_dec_objs(split);
+		if (deinterleave) DA_NoNulling_dec_objs(deinterleave);
+
+		DA_gst_caps_unref(udp_caps); 
+		udp_caps = NULL;
+		DA_gst_caps_unref(rx_caps); 
+		rx_caps = NULL;
+	}
+
+	if (data->direction & DIRECTION_TX) {
+		GstElement *udpsink = NULL;
+		GstElement *tx_audioconv = NULL;
+		GstElement *audiointerleave = NULL;
+		GstElement *capsfilter = NULL;
+		GstElement *tx_valve = NULL;
+		GstElement *appsrc = NULL;
+		GstCaps	*caps = NULL;
+
+		audiointerleave = AL_gst_element_factory_make("audiointerleave", "audiointerleave"); // allocates memory!
+		gst_bin_add(GST_BIN(pipeline), audiointerleave);
+		g_atomic_int_inc(&stream->pipeline_elements_count); // audiointerleave
+		g_object_set(audiointerleave, "start-time-selection", GST_AGGREGATOR_START_TIME_SELECTION_FIRST, NULL);
+		g_object_set(audiointerleave, "output-buffer-duration", data->codec_ms * GST_MSECOND, NULL);
+
+		if (data->tx_codec == L16) {
+			rtp_pay = AL_gst_element_factory_make("rtpL16pay", "rtp-pay");
+
+		} else {
+			rtp_pay = AL_gst_element_factory_make("rtpL24pay", "rtp-pay");
+		}
+		g_object_set(rtp_pay, "pt", data->rtp_payload_type, NULL);
+
+		if (data->ptime_ms != -1.0) {
+			g_object_set(rtp_pay, "max-ptime", (gint64)(data->ptime_ms * 1000000), "min-ptime",
+						 (gint64)(data->ptime_ms * 1000000), NULL);
+		}
+
+		
+		for (gint ch = 0; ch < data->channels; ch++) {
+			gchar name[ELEMENT_NAME_SIZE];
+			gchar pad_name[STR_SIZE];
+
+			NAME_ELEMENT(name, "appsrc", ch);
+			g_snprintf(pad_name, STR_SIZE, "sink_%u", ch);
+
+			appsrc = gst_element_factory_make("appsrc", name);			//do not count - deallocated automatically
+			if (!appsrc) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to create %s \n", name);
+				continue;
+			}
+
+			/*Always accept S16LE from the FS*/
+			caps = gst_caps_new_simple("audio/x-raw", 
+				"rate", G_TYPE_INT, data->sample_rate, 
+				"channels", G_TYPE_INT, 1,
+				"format", G_TYPE_STRING, "S16LE", 
+				"layout", G_TYPE_STRING, "interleaved",
+			   "channel-mask", GST_TYPE_BITMASK, (guint64)0, NULL);
+
+			g_object_set(appsrc, "format", GST_FORMAT_TIME, NULL);
+			g_object_set(appsrc, "do-timestamp", TRUE, NULL);
+			g_object_set(appsrc, "is-live", TRUE, NULL);
+			/* Second * 3 allows a little bit of headroom */
+			g_object_set(appsrc, "max-bytes", data->codec_ms * data->sample_rate * 2 * 3 / 1000, NULL);
+
+			g_object_set(appsrc, "caps", caps, NULL);
+			DA_gst_caps_unref(caps);
+			caps = NULL;
+			gst_bin_add(GST_BIN(pipeline), appsrc);
+
+			if (!gst_element_link_pads(appsrc, "src", audiointerleave, pad_name)) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+								  "Failed to link pads of %s with audiointerleave\n", name);
+				goto ddirTX_error;				// on errors, dealloc of added elemets occurs when pipeline de-allocated
+			}
+			//do not remove appsrc, it goes when pipeline is torn down
+		}
+
+		tx_valve = AL_gst_element_factory_make("valve", "tx-valve");
+		g_object_set(tx_valve, "drop", data->txdrop, NULL);
+
+		capsfilter = AL_gst_element_factory_make("capsfilter", "tx-capsf");
+
+		tx_audioconv = AL_gst_element_factory_make("audioconvert", "tx-audioconv");
+		g_object_set(tx_audioconv, "dithering", 0 /* none */, NULL);
+
+		udpsink = AL_gst_element_factory_make("udpsink", "tx-sink");
+
+		caps = gst_caps_new_simple("audio/x-raw", 
+			"rate", G_TYPE_INT, data->sample_rate, 
+			"channels", G_TYPE_INT,  data->channels, 
+			"format", G_TYPE_STRING, "S16LE", 
+			"layout", G_TYPE_STRING, "interleaved", 
+			"channel-mask", GST_TYPE_BITMASK, (guint64)0, 
+			NULL);
+
+		g_object_set(capsfilter, "caps", caps, NULL);
+		DA_gst_caps_unref(caps);
+		caps = NULL;
+
+		g_object_set(udpsink, 
+		"host", data->tx_ip_addr, 
+		"port", data->tx_port, 
+		"multicast-iface", data->rtp_iface,
+					 NULL);
+		g_object_set(udpsink, "sync", TRUE, "async", FALSE, NULL);
+		g_object_set(udpsink, "qos", TRUE, "qos-dscp", 34, NULL);
+		g_object_set(udpsink, "processing-deadline", 0 * GST_MSECOND, NULL);
+		if (data->is_backup_sender) {
+#ifndef _WIN32
+			// Disable IP_MULTICAST_LOOP to avoid listening packets from same host
+			// For Linux this needs to be set on the sender's side
+			g_object_set(udpsink, "loop", FALSE, NULL);
+#endif
+		}
+
+		if (!audiointerleave || !tx_valve || !tx_audioconv || !rtp_pay || !udpsink) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to create tx elements\n");
+			goto ddirTX_error;
+		}
+
+		gst_bin_add_many(GST_BIN(pipeline), tx_valve, capsfilter, tx_audioconv, rtp_pay, udpsink, NULL);
+		g_atomic_int_add(&stream->pipeline_elements_count, 5);
+
+		if (!gst_element_link_many(audiointerleave, tx_valve, capsfilter, tx_audioconv, rtp_pay, udpsink, NULL)) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to link elements");
+			goto ddirTX_error;
+		}
+
+
+		goto ddirTX_exit;
+
+	ddirTX_error:
+		DA_gst_caps_unref(caps);
+		caps = NULL;
+		DA_gst_object_unref(GST_OBJECT(udpsink));
+		udpsink = NULL;
+		DA_gst_object_unref(GST_OBJECT(tx_audioconv));
+		tx_audioconv = NULL;
+		DA_gst_object_unref(GST_OBJECT(audiointerleave));
+		audiointerleave = NULL;
+		DA_gst_object_unref(GST_OBJECT(capsfilter));
+		capsfilter = NULL;
+		DA_gst_object_unref(GST_OBJECT(tx_valve));
+		tx_valve = NULL;
+		gst_object_unref(GST_OBJECT(appsrc));
+		appsrc = NULL; // added to pipeline in loop, not counted
+		goto error;
+
+	ddirTX_exit:
+		//accounting
+		DA_NoNulling_dec_objs(GST_OBJECT(udpsink));
+		DA_NoNulling_dec_objs(GST_OBJECT(tx_audioconv));
+		DA_NoNulling_dec_objs(GST_OBJECT(audiointerleave));
+		DA_NoNulling_dec_objs(GST_OBJECT(capsfilter));
+		DA_NoNulling_dec_objs(GST_OBJECT(tx_valve));
+		// rtp_pay done later
+		// appsrc not counted added to pipeline in loop, not counted
+	}
+
+	/* if this stream is configured to be a backup sender, we pause our Tx if we find another sender doing Tx
+	  on the same multicast address and resume once the remote sender stops
+	*/
+	GstElement *udpsrc = NULL;
+	GstElement *fakesink = NULL;
+	GstCaps *caps = NULL;
+	if (data->is_backup_sender) {
+
+		/* create a dummy pipeline with `udpsrc ! fakesink` just to receive on udp and read the last-sample from
+		 * fakesink */
+#ifndef ENABLE_THREADSHARE
+		udpsrc = AL_gst_element_factory_make("udpsrc", "tx-monitor-udpsrc");
+#else
+		MAKE_TS_ELEMENT(udpsrc, "ts-udpsrc", "tx-monitor-udpsrc", ts_ctx);
 #endif
 
-    fakesink = gst_element_factory_make ("fakesink", "tx-monitor-fakesink");
+		fakesink = AL_gst_element_factory_make("fakesink", "tx-monitor-fakesink");
 
-    if (data->tx_codec == L16) {
-      caps = gst_caps_new_simple ("application/x-rtp",
-          "clock-rate", G_TYPE_INT, data->sample_rate,
-          "channels", G_TYPE_INT, data->channels,
-          "channel-order", G_TYPE_STRING, "unpositioned",
-          "encoding-name", G_TYPE_STRING, "L16",
-          "media", G_TYPE_STRING, "audio", NULL);
-    } else {
-      caps = gst_caps_new_simple ("application/x-rtp",
-          "clock-rate", G_TYPE_INT, data->sample_rate,
-          "channels", G_TYPE_INT, data->channels,
-          "channel-order", G_TYPE_STRING, "unpositioned",
-          "encoding-name", G_TYPE_STRING, "L24",
-          "media", G_TYPE_STRING, "audio", NULL);
-    }
+		if (data->tx_codec == L16) {
+				caps =	gst_caps_new_simple("application/x-rtp", 
+				"clock-rate", G_TYPE_INT, data->sample_rate, 
+				"channels",	G_TYPE_INT, data->channels, 
+				"channel-order", G_TYPE_STRING, "unpositioned",
+				"encoding-name", G_TYPE_STRING, "L16", 
+				"media", G_TYPE_STRING, "audio", NULL);
+		} else {
+				caps = gst_caps_new_simple("application/x-rtp", 
+				"clock-rate", G_TYPE_INT, data->sample_rate, 
+				"channels",	G_TYPE_INT, data->channels, 
+				"channel-order", G_TYPE_STRING, "unpositioned",
+				"encoding-name", G_TYPE_STRING, "L24", 
+				"media", G_TYPE_STRING, "audio", NULL);
+		}
 
-    if (!udpsrc || !fakesink) {
-      switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to create tx-monitor elements, cannot listen for primary sender\n");
-		goto bksnd_error;
-    } else {
-      g_object_set (udpsrc,
-        "address", data->tx_ip_addr, "port", data->tx_port,
-#ifdef _WIN32
-        // Disable IP_MULTICAST_LOOP to avoid listening packets from same host
-        // For Windows this needs to be set on the receiver's side
-         "loop", FALSE,
-#endif
-        "multicast-iface", data->rtp_iface, "caps", caps, NULL);
+		if (!udpsrc || !fakesink) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+							  "Failed to create tx-monitor elements, cannot listen for primary sender\n");
+			goto bksnd_error;
+		} else {
+			g_object_set(udpsrc, "address", data->tx_ip_addr, "port", data->tx_port,
+						 // #ifdef _WIN32
+						 //  Disable IP_MULTICAST_LOOP to avoid listening packets from same host
+						 //  For Windows this needs to be set on the receiver's side
+						 "loop", FALSE,
+						 // #endif
+						 "multicast-iface", data->rtp_iface, "caps", caps, NULL);
 
-      g_object_set(fakesink, "async", FALSE, NULL);
+			g_object_set(fakesink, "async", FALSE, NULL);
 
-      gst_bin_add_many (GST_BIN (pipeline), udpsrc, fakesink, NULL);
-      if (!gst_element_link_many (udpsrc, fakesink, NULL)) {
-        switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to link tx-monitor elements, cannot listen for primary sender\n");
-		  goto bksnd_error;
-      } else {
-        stream->pause_backup_sender = FALSE;
-        stream->backup_sender_idle_wait_ms = data->backup_sender_idle_wait_ms;
+			gst_bin_add_many(GST_BIN(pipeline), udpsrc, fakesink, NULL);
+			// Count backup sender elements that were allocated via AL_ wrappers:
+			// udpsrc, fakesink = 2 elements
+			g_atomic_int_add(&stream->pipeline_elements_count, 2);
 
-        /* add a timer to check for remote sender's buffers every `backup_sender_idle_wait_ms` to resumek
-          our Tx as soon as possible once the remote Tx stops */
-        stream->backup_sender_idle_timer = g_timeout_add_full(G_PRIORITY_DEFAULT,
-          data->backup_sender_idle_wait_ms, backup_sender_timeout_cb, stream, NULL);
-      }
-    }
+			if (!gst_element_link_many(udpsrc, fakesink, NULL)) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+								  "Failed to link tx-monitor elements, cannot listen for primary sender\n");
+				goto bksnd_error;
+			} else {
+				stream->pause_backup_sender = FALSE;
+				stream->backup_sender_idle_wait_ms = data->backup_sender_idle_wait_ms;
 
-	goto bksnd_exit;
+				/* add a timer to check for remote sender's buffers every `backup_sender_idle_wait_ms` to resumek
+				  our Tx as soon as possible once the remote Tx stops */
+				stream->backup_sender_idle_timer = g_timeout_add_full(
+					G_PRIORITY_DEFAULT, data->backup_sender_idle_wait_ms, backup_sender_timeout_cb, stream, NULL);
+			}
+		}
+		DA_gst_caps_unref(caps);
+		caps = NULL;
 
-bksnd_error:
-    if (udpsrc !=NULL) gst_object_unref(udpsrc);
-	if (fakesink != NULL) gst_object_unref(fakesink);
-	if (caps!=NULL) gst_caps_unref(caps);
-	goto error;
+		GstStateChangeReturn ret = gst_element_set_state(pipeline, GST_STATE_PAUSED); // added extra check
+		if (ret == GST_STATE_CHANGE_FAILURE) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Pipeline state change failed\n");
+			goto bksnd_error;
+		}
 
-bksnd_exit:
-	gst_caps_unref(caps);
-  }
+// normal exit
+		DA_gst_caps_unref(caps);
+		caps = NULL;
+		DA_NoNulling_dec_objs(udpsrc);
+		DA_NoNulling_dec_objs(fakesink);
 
+		goto bksnd_continue;
 
+	bksnd_error:
+		DA_gst_caps_unref(caps);
+		caps = NULL;
+		DA_gst_object_unref(GST_OBJECT(udpsrc));
+		udpsrc = NULL;
+		DA_gst_object_unref(GST_OBJECT(fakesink));
+		fakesink = NULL;
+		goto error;
+	}
 
-  bus = gst_pipeline_get_bus (GST_PIPELINE (pipeline));
-  gst_bus_add_watch (bus, bus_callback, stream);
-  gst_object_unref(bus);
-  bus = NULL;
+	// ---
+bksnd_continue: 
+	bus = AL_gst_pipeline_get_bus(GST_PIPELINE(pipeline));
+	gst_bus_add_watch(bus, bus_callback, stream);
+	DA_gst_object_unref(GST_OBJECT(bus));
+	bus = NULL;
 
-  stream->error_cb = error_cb;
-  stream->pipeline = GST_PIPELINE (pipeline);
-  stream->mainloop = g_main_loop_new (NULL, FALSE);
-  stream->thread = g_thread_new (pipeline_name, start_pipeline, stream);
-  stream->sample_rate = data->sample_rate;
+	stream->error_cb = error_cb;
+	stream->pipeline = GST_PIPELINE(pipeline);
+	stream->mainloop = g_main_loop_new(NULL, FALSE);
+	stream->thread = g_thread_new(pipeline_name, start_pipeline, stream);
+	stream->sample_rate = data->sample_rate;
 
-  g_atomic_int_set (&stream->clock_sync, 0);
+	g_atomic_int_set(&stream->clock_sync, 0);
 
-  gst_element_set_start_time(pipeline, GST_CLOCK_TIME_NONE);
-  gst_element_set_base_time(pipeline, 0);
+	gst_element_set_start_time(pipeline, GST_CLOCK_TIME_NONE);
+	gst_element_set_base_time(pipeline, 0);
 
-  if (rtp_pay) {
-    /* We have data->codec_ms of latency in the audiointerleave, so add that in */
-    /* FIXME: we should be cleverer and apply the pipeline latency as computed instead */
-    g_object_set (rtp_pay, "timestamp-offset",
-        gst_util_uint64_scale_int ((data->codec_ms + data->rtp_ts_offset) * GST_MSECOND, data->sample_rate, 
-            GST_SECOND)
-          % G_MAXUINT32,
-        NULL);
-  }
+	if (rtp_pay) {
+		/* We have data->codec_ms of latency in the audiointerleave, so add that in */
+		/* FIXME: we should be cleverer and apply the pipeline latency as computed instead */
+		g_object_set(rtp_pay, "timestamp-offset",
+					 gst_util_uint64_scale_int((data->codec_ms + data->rtp_ts_offset) * GST_MSECOND, data->sample_rate,
+											   GST_SECOND) % G_MAXUINT32, NULL);
+	}
 
-  if (rtpdepay && data->synthetic_ptp) {
-	  if (stream->clock) {
-		  gst_object_unref(GST_OBJECT(stream->clock));
-		  stream->clock = g_object_new(GST_TYPE_SYSTEM_CLOCK, "name", "SyntheticPtpClock", NULL);
-	  }
-      stream->cb_rx_stats_id =
-      g_timeout_add_full(G_PRIORITY_DEFAULT, SYNTHETIC_CLOCK_INTERVAL_MS, update_clock, stream, NULL);
-    /* We'll set the pipeline clock once it's synced */
-  } else {
-        stream->clock = NULL;
-        gst_pipeline_use_clock (GST_PIPELINE(pipeline), data->clock);
-        g_atomic_int_set (&stream->clock_sync, 1);
-  }
+	if (rtpdepay && data->synthetic_ptp) {
+		if (stream->clock) {
+			DA_gst_object_unref(GST_OBJECT(stream->clock)); // check - added
+			stream->clock = NULL;
+		}
+		stream->clock = AL_g_object_new_clock(GST_TYPE_SYSTEM_CLOCK, "name", "SyntheticPtpClock", NULL);
 
-  for (guint ch = 0; ch < MAX_IO_CHANNELS; ch++)
-    stream->leftover_bytes[ch] = 0;
+		stream->cb_rx_stats_id =
+			g_timeout_add_full(G_PRIORITY_DEFAULT, SYNTHETIC_CLOCK_INTERVAL_MS, update_clock, stream, NULL);
+		/* We'll set the pipeline clock once it's synced */
+	} else {
+		if (stream->clock) {
+			DA_gst_object_unref(GST_OBJECT(stream->clock)); /// added check
+			stream->clock = NULL;
+		}
+		gst_pipeline_use_clock(GST_PIPELINE(pipeline), data->clock);
+		g_atomic_int_set(&stream->clock_sync, 1);
+	}
 
-  goto exit;
+	for (guint ch = 0; ch < MAX_IO_CHANNELS; ch++) 
+		stream->leftover_bytes[ch] = 0;
+	goto exit;
 
 error:
-    if (pipeline !=NULL) gst_object_unref(GST_OBJECT(pipeline));
-	if (rtp_pay != NULL) gst_object_unref(GST_OBJECT(rtp_pay));
+	if (pipeline) gst_element_set_state(pipeline, GST_STATE_NULL); // added check
+	DA_gst_object_unref(GST_OBJECT(pipeline));
+	pipeline = NULL;
+	DA_gst_object_unref(GST_OBJECT(rtp_pay));
+	rtp_pay = NULL;
+
 	if (stream != NULL) {
 		if (stream->clock != NULL) {
-			gst_object_unref(stream->clock); // Fix: Added missing unref
+			DA_gst_object_unref(GST_OBJECT(stream->clock)); // added - check
+			stream->clock = NULL;
+		} else {
+			DA_NoNulling_dec_objs(GST_OBJECT(stream->clock)); // accounting
 		}
-		g_free(stream);
+		teardown_mainloop(stream->mainloop);							   // added - check
+		if (stream->mainloop != NULL) g_main_loop_unref(stream->mainloop); // added - check
+		if (stream->thread != NULL) g_thread_join(stream->thread);		   // added - check
+		g_free(stream);			//not counted
+		stream = NULL;
 	}
 	return NULL;
+
 exit:
-    return stream;
-}
-
-void
-use_ptp_clock(g_stream_t *stream, GstClock *ptp_clock)
-{
-  g_atomic_int_set(&stream->clock_sync, 0);
-  gst_element_set_state(GST_ELEMENT (stream->pipeline), GST_STATE_READY);
-
-  /* cb_rx_stats_id will be non zero only when
-  Rx is operational and pipeline clock is not ptp*/
-  if (stream->cb_rx_stats_id) {
-    g_source_remove(stream->cb_rx_stats_id);
-    stream->cb_rx_stats_id = 0;
-  }
-
-  if (stream->clock) {
-    gst_object_unref (stream->clock);
-    stream->clock = NULL;
-  }
-
-  gst_pipeline_use_clock(GST_PIPELINE(stream->pipeline), ptp_clock);
-  gst_pipeline_set_clock(GST_PIPELINE(stream->pipeline), ptp_clock);
-  gst_element_set_state(GST_ELEMENT (stream->pipeline), GST_STATE_PLAYING);
-  dump_pipeline(stream->pipeline, "ptp-clock-switch");
-
-  g_atomic_int_set (&stream->clock_sync, 1);
-}
-
-void *
-start_pipeline (void *data)
-{
-  g_stream_t *stream = (g_stream_t *) data;
-  gst_element_set_state (GST_ELEMENT (stream->pipeline), GST_STATE_PLAYING);
-
-  dump_pipeline(stream->pipeline, "start-pipeline");
-  start_mainloop (stream->mainloop);
-  return NULL;
-}
-
-void
-stop_pipeline (g_stream_t * stream)
-{
-  GstBus *bus;
-
-  dump_pipeline(stream->pipeline, "pipeline-stop");
-
-  gst_element_set_state (GST_ELEMENT (stream->pipeline), GST_STATE_NULL);
-
-  /* cb_rx_stats_id will be non zero only when
-  Rx is operational and pipeline clock is not ptp*/
-  if (stream->cb_rx_stats_id)
-    g_source_remove(stream->cb_rx_stats_id);
-
-  if (stream->backup_sender_idle_timer)
-    g_source_remove(stream->backup_sender_idle_timer);
-
-  bus = gst_pipeline_get_bus (GST_PIPELINE (stream->pipeline));
-  gst_bus_remove_watch (bus);
-  gst_object_unref(GST_OBJECT(bus));
-  bus = NULL;
-
-  gst_object_unref (GST_OBJECT(stream->pipeline));
-  if (stream->clock)
-	gst_object_unref (GST_OBJECT(stream->clock));
-  teardown_mainloop (stream->mainloop);
-  g_thread_join (stream->thread);
-
-  if (stream != NULL) g_free(stream); 
-  switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
-      "Pipeline and mainloop cleaned up\n");
-
-}
-
-void
-teardown_mainloop (GMainLoop * mainloop)
-{
-
-  g_main_loop_quit (mainloop);
-  g_main_loop_unref (mainloop);
+	// accounting
+	DA_NoNulling_dec_objs(pipeline);
+	DA_NoNulling_dec_objs(rtp_pay);
+	DA_NoNulling_dec_objs(stream->clock);
+	//DA_NoNulling_dec_chars(stream);  not counted
+	DA_NoNulling_dec_objs(udpsrc);
+	DA_NoNulling_dec_objs(fakesink);
+	g_atomic_int_set(&stream->pipeline_active, 1); // Mark as active
+	return stream;
 }
 
 
-void
-start_mainloop (GMainLoop * mainloop)
+void use_ptp_clock(g_stream_t *stream, GstClock *ptp_clock)		//locked by caller
 {
+	if (!stream) goto error; //added check
+	if (!g_atomic_int_get(&stream->pipeline_active)) { 
+		goto error;
+	}
 
-  switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Running mainloop\n");
-  g_main_loop_run (mainloop);
-}
 
+	g_atomic_int_set(&stream->clock_sync, 0);
+	gst_element_set_state(GST_ELEMENT(stream->pipeline), GST_STATE_READY);
 
-gboolean
-push_buffer (g_stream_t *stream, unsigned char *payload, guint len,
-    guint ch_idx, switch_timer_t * timer)
-{
-  GstState cur_state = GST_STATE_NULL, pending_state;
-  GstBuffer *buf =NULL;
-  GstMapInfo info;
+	/* cb_rx_stats_id will be non zero only when
+	Rx is operational and pipeline clock is not ptp*/
+	if (stream->cb_rx_stats_id) {
+		g_source_remove(stream->cb_rx_stats_id);
+		stream->cb_rx_stats_id = 0;
+	}
 
-  gboolean ret=FALSE;
-  GstFlowReturn result;
+	if (stream->clock) {
+		DA_gst_object_unref(GST_OBJECT(stream->clock)); // added check
+		stream->clock = NULL;
+	} else {
+		DA_NoNulling_dec_objs(GST_OBJECT(stream->clock)); // accounting
+	}
+ 
+	gst_pipeline_use_clock(GST_PIPELINE(stream->pipeline), ptp_clock);		
+	gst_pipeline_set_clock(GST_PIPELINE(stream->pipeline), ptp_clock);		
+	gst_element_set_state(GST_ELEMENT(stream->pipeline), GST_STATE_PLAYING);	
+	dump_pipeline(stream->pipeline, "ptp-clock-switch");
+	g_atomic_int_set(&stream->clock_sync, 1);
 
-  gchar name[ELEMENT_NAME_SIZE];
-  GstElement *appsrc = NULL;
-  GstPipeline *pipeline = stream->pipeline;
-
-  NAME_ELEMENT (name, "appsrc", ch_idx);
-  appsrc = gst_bin_get_by_name (GST_BIN (pipeline), name);
-
-  switch_core_timer_next (timer);
-
-  if (appsrc == NULL) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
-        "Failed to find appsrc in the pipeline\n");
-	  goto error;
-  }
-
-  if (!g_atomic_int_get(&stream->clock_sync)) {
-	result = TRUE;
-    goto done;
-  }
-
-  gst_element_get_state (GST_ELEMENT (pipeline), &cur_state, &pending_state, 0);
-  if (cur_state != GST_STATE_PAUSED && cur_state != GST_STATE_PLAYING) {
-    result = TRUE;
-    goto done;
-  }
-
-  buf = gst_buffer_new_allocate (NULL, len, NULL);
-  if (buf == NULL) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to allocate buffer\n");
-    goto error;
-  }
-
-  if (!gst_buffer_map (buf, &info, GST_MAP_WRITE)) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to get buffer map\n");
-    goto error;
-  }
-  memcpy (info.data, payload, len);
-  gst_buffer_unmap (buf, &info);
-
-  
-  g_signal_emit_by_name (appsrc, "push-buffer", buf, &result);
-  // switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Pushed buffer\n");
-
-  gst_buffer_unref(buf);
-  buf = NULL;
-  if (result == GST_FLOW_ERROR) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to do 'push-buffer' \n");
-    goto error;
-  }
-
-done:
-  ret = TRUE;
 
 error:
-  gst_object_unref (GST_OBJECT (appsrc));
-	if (buf != NULL) gst_object_unref(GST_OBJECT(buf));
-  return ret;
+	return;
+}
+
+void *start_pipeline(void *data)
+{
+	g_stream_t *stream = (g_stream_t *)data;
+	gst_element_set_state(GST_ELEMENT(stream->pipeline), GST_STATE_PLAYING);
+
+	dump_pipeline(stream->pipeline, "start-pipeline");
+	start_mainloop(stream->mainloop);
+	return NULL;
 }
 
 
-int
-pull_buffers (g_stream_t * stream, unsigned char *payload, guint needed_bytes,
-    guint ch_idx, switch_timer_t * timer, gchar *session)
+// Here be demons - be careful what you change and maintain order of operations
+// if this runs while calls are in progress, some deallocations do not occur
+// this is why there is the atomic flag that indicates it is in progress
+// and it must be checked in critical sections push pull bufs and pad ops
+//
+void stop_pipeline(g_stream_t *stream)
 {
-  GstState cur_state = GST_STATE_NULL, pending_state;
+	if (!stream) goto error_no_unlock;
 
-  GstBuffer *buf=NULL;
-  GstSample *sample=NULL;
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Stopping pipeline...\n");
+	// CRITICAL: Set flag to 0  this immediately stops audio I/O
+	g_atomic_int_set(&stream->pipeline_active, 0);
 
-  GstMapInfo info;
-  int total_bytes = 0;
-  gchar name[ELEMENT_NAME_SIZE];
-  GstElement *appsink =NULL;
+	// Give active threads time to see flag and exit cleanly
+	g_usleep(50000); // 50ms should be sufficient (pull timeout is 10ms)
 
-  if (session == NULL)
-    NAME_ELEMENT (name, "appsink", ch_idx);
-  else
-    NAME_SESSION_ELEMENT(name, "appsink", ch_idx, session);
+	// STOP ALL TIMERS/SOURCES FIRST (atomic)
+	gint timer_id = g_atomic_int_exchange_and_add(&stream->backup_sender_idle_timer, 0);
+	if (timer_id > 0) {
+		g_source_remove(timer_id);
+		g_atomic_int_set(&stream->backup_sender_idle_timer, 0);
+	}
 
-  appsink = gst_bin_get_by_name (GST_BIN (stream->pipeline), name);
+	if (stream->bus_watch_id > 0) {
+		g_source_remove(stream->bus_watch_id);
+		stream->bus_watch_id = 0;
+	}
 
-  if (appsink == NULL) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to find %s in the pipeline\n", name);
-    return 0;
-  }
+	if (stream->cb_rx_stats_id > 0) {
+		g_source_remove(stream->cb_rx_stats_id);
+		stream->cb_rx_stats_id = 0;
+	}
 
-  gst_element_get_state (GST_ELEMENT (stream->pipeline), &cur_state,
-      &pending_state, 0);
-  if (cur_state != GST_STATE_PAUSED && cur_state != GST_STATE_PLAYING)
-    goto out;
+	// DISCONNECT SIGNALS BEFORE NULL STATE (CRITICAL - elements still exist)
+	if (stream->deinterleave_signal_id > 0) {
+		GstElement *deinterleave = AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), "rx-deinterleave");
+		if (deinterleave) {
+			g_signal_handler_block(deinterleave, stream->deinterleave_signal_id); // Block first
+			g_signal_handler_disconnect(deinterleave, stream->deinterleave_signal_id);
+			DA_gst_object_unref(GST_OBJECT(deinterleave));
+			deinterleave = NULL;
+		}
+		stream->deinterleave_signal_id = 0;
+	}
 
-  if (gst_app_sink_is_eos (GST_APP_SINK (appsink)))
-    goto out;
+	if (stream->jitterbuf_signal_id > 0) {
+		GstElement *rtpjitbuf = AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), "rx-jitbuf");
+		if (rtpjitbuf) {
+			g_signal_handler_disconnect(rtpjitbuf, stream->jitterbuf_signal_id);
+			DA_gst_object_unref(GST_OBJECT(rtpjitbuf));
+			rtpjitbuf = NULL;
+		}
+		stream->jitterbuf_signal_id = 0;
+	}
 
-  // Note: assumes leftover_bytes will never be more than buflen, which is
-  // likely true (packet is limited to MTU, while buflen is 8192)
-  // FIXME: revisit this to check whether we need this anymore
-  if (stream->leftover_bytes[ch_idx]) {
-    int copy =
-        stream->leftover_bytes[ch_idx] <=
-        needed_bytes ? stream->leftover_bytes[ch_idx] : needed_bytes;
-    memcpy (payload, stream->leftover[ch_idx], copy);
-    total_bytes += copy;
-    stream->leftover_bytes[ch_idx] -= copy;
-  }
 
-  while (total_bytes < needed_bytes) {
-    // switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "pulling buffer\n");
-    sample =
-        gst_app_sink_try_pull_sample (GST_APP_SINK (appsink),
-        10 * GST_MSECOND);
-    if (!sample) {
-      // switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Failed to pull sample\n");
-      switch_cond_next ();
-      break;
-    }
-    buf = gst_sample_get_buffer (sample);
+	// Account for elements that will be freed when pipeline is destroyed:
+	int remaining = g_atomic_int_get(&stream->pipeline_elements_count);
+	if (remaining > 0) {
+		g_alloc_counts.objs -= remaining;
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
+						  "Accounted for %d elements that will be destroyed with pipeline\n", remaining);
+	} else if (remaining < 0) {
+		// This indicates a bug: more removes than adds
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "ERROR: pipeline_elements_count is negative (%d) - accounting mismatch!\n", remaining);
+	}
+	// DUMP PIPELINE (still live)
+	dump_pipeline(stream->pipeline, "pipeline-stop");
 
-    if (!buf)
-      continue;
+	// Drain all appsinks BEFORE setting pipeline to NULL
+	GstIterator *iter = gst_bin_iterate_elements(GST_BIN(stream->pipeline));
+	GValue item = G_VALUE_INIT;
 
-    if (gst_buffer_map (buf, &info, GST_MAP_READ)) {
-      if (total_bytes + info.size > needed_bytes) {
-        int want = needed_bytes - total_bytes;
+	while (gst_iterator_next(iter, &item) == GST_ITERATOR_OK) {
+		GstElement *element = g_value_get_object(&item);
 
-        stream->leftover_bytes[ch_idx] = info.size - want;
-        memcpy (stream->leftover[ch_idx], info.data + want,
-            stream->leftover_bytes[ch_idx]);
+		// Check if this is an appsink
+		if (GST_IS_APP_SINK(element)) {
+			GstSample *sample;
 
-        info.size = want;
-      }
+			// Drain all samples from this appsink
+			while ((sample = gst_app_sink_try_pull_sample(GST_APP_SINK(element), 0))) { DA_gst_sample_unref(sample); }
+		}
 
-      memcpy (payload + total_bytes, info.data, info.size);
-      total_bytes += info.size;
-    }
-    gst_buffer_unmap (buf, &info);
-	if (sample != NULL) gst_sample_unref(sample);
-	sample = NULL;
+		g_value_reset(&item);
+	}
 
-    // switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Got %d\n", total_bytes);
-  }
+	gst_iterator_free(iter);
+
+	// NULL STATE - destroys ALL elements safely
+	//switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Setting pipeline to NULL...\n");
+	gst_element_set_state(GST_ELEMENT(stream->pipeline), GST_STATE_NULL);
+
+	GstState state, pending;
+	GstStateChangeReturn ret = gst_element_get_state(
+		GST_OBJECT(stream->pipeline), &state, &pending, 5 * GST_SECOND); /* or GST_CLOCK_TIME_NONE */
+
+	if (ret != GST_STATE_CHANGE_SUCCESS || state != GST_STATE_NULL) { 
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Unable to stop pipeline ..\n");
+		// goto exit_unlock; 
+		// drop through to cleanup anyhow
+	}
+
+	// UNREF PIPELINE (frees everything)
+	DA_gst_object_unref(GST_OBJECT(stream->pipeline));
+	stream->pipeline = NULL;
+
+	// CLEANUP CLOCK
+	if (stream->clock) {
+		DA_gst_object_unref(GST_OBJECT(stream->clock));
+		stream->clock = NULL;
+	} else {
+		DA_NoNulling_dec_objs(GST_OBJECT(stream->clock)); // accounting
+	}
+
+	// MAINLOOP + THREADS
+	teardown_mainloop(stream->mainloop);
+	if (stream->thread != NULL) {
+		g_thread_join(stream->thread);
+		stream->thread = NULL;
+	}
+
+	// MUTEX CLEANUP 
+	for (int i = 0; i < MAX_IO_CHANNELS; i++) {
+		// Try to ensure mutex is unlocked
+		if (g_rec_mutex_trylock(&stream->appsrc_mutexes[i])) { g_rec_mutex_unlock(&stream->appsrc_mutexes[i]); }
+		g_rec_mutex_clear(&stream->appsrc_mutexes[i]);
+	}
+
+	//  FINAL FREE
+	g_free(stream);
+
+
+exit_unlock:
+	if (timer_id > 0) {
+		g_source_remove(timer_id);
+		g_atomic_int_set(&stream->backup_sender_idle_timer, 0);
+	}
+	//
+	periodic_mem_check(FALSE); // de allocate memory here if required
+	//
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Pipeline and mainloop cleaned up\n");
+	return;
+
+error_no_unlock:
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Pipeline stop error, no stream found\n");
+	return;
+}
+
+
+
+void teardown_mainloop(GMainLoop *mainloop)
+{
+	g_main_loop_quit(mainloop);
+	g_main_loop_unref(mainloop);
+}
+
+
+void start_mainloop(GMainLoop *mainloop)
+{
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Running mainloop\n");
+	g_main_loop_run(mainloop);
+
+}
+
+
+gboolean push_buffer(g_stream_t *stream, unsigned char *payload, guint len, guint ch_idx, switch_timer_t *timer)
+{
+	gboolean retval = FALSE;
+	GstElement *appsrc = NULL;
+	GstBuffer *buf = NULL;
+	// Fast atomic check
+	if (!stream || ch_idx >= MAX_IO_CHANNELS 
+		|| !g_atomic_int_get(&stream->pipeline_active)) {
+		goto error; // Pipeline stopping, bail immediately
+	}
+
+	// per channel lock
+	GRecMutex *ch_mutex = &stream->appsrc_mutexes[ch_idx];
+	g_rec_mutex_lock(ch_mutex);
+
+	GstPipeline *pipeline = stream->pipeline;
+	if (!pipeline || !g_atomic_int_get(&stream->pipeline_active)) { // added check
+		goto exit;
+	}
+
+	GstState cur_state = GST_STATE_NULL;
+	GstState pending_state = GST_STATE_NULL;
+
+	GstMapInfo info;
+	GstFlowReturn result;
+	gchar name[ELEMENT_NAME_SIZE];
+
+
+	NAME_ELEMENT(name, "appsrc", ch_idx);
+	appsrc = AL_gst_bin_get_by_name(GST_BIN(pipeline), name);	//check 
+
+  	g_rec_mutex_unlock(ch_mutex);
+	switch_core_timer_next(timer);						//wait a bit
+	g_rec_mutex_lock(ch_mutex);
+
+	if (!appsrc ) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Failed to find appsrc in the pipeline\n");
+		goto exit;
+	}
+
+			
+	if (!g_atomic_int_get(&stream->clock_sync)) {
+		retval = TRUE;
+		goto exit;
+	}
+
+	gst_element_get_state(GST_ELEMENT(pipeline), &cur_state, &pending_state, 0);
+	if (cur_state != GST_STATE_PAUSED && cur_state != GST_STATE_PLAYING) {
+		retval = TRUE;
+		goto exit;
+	}
+
+
+	buf = AL_gst_buffer_new_allocate(NULL, len, NULL);			
+	if (!buf ) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to allocate buffer\n");
+		goto exit; 
+	}
+
+	if (!gst_buffer_map(buf, &info, GST_MAP_WRITE)) {		//MU here kills audio from phone to BP
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to get buffer map\n");
+		goto exit; 
+	}
+
+	memcpy(info.data, payload, len);
+	gst_buffer_unmap(buf, &info);	
+
+	g_signal_emit_by_name(appsrc, "push-buffer", buf, &result);
+	// switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Pushed buffer\n");
+
+
+	if (result == GST_FLOW_ERROR) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to do 'push-buffer' \n");
+		goto exit;
+	}
+	// fall thru, no error
+
+	retval = TRUE;
+
+exit:
+	DA_gst_buffer_unref(buf);
+	DA_gst_object_unref(GST_OBJECT(appsrc));
+	g_rec_mutex_unlock(ch_mutex);
+	return retval;
+
+error:
+	return 0;
+}
+
+//
+// critical to manage threads properly here
+//
+int pull_buffers(g_stream_t *stream, unsigned char *payload, 
+				guint needed_bytes, guint ch_idx, switch_timer_t *timer,
+				 gchar *session)
+{
+	GstBuffer *buf = NULL;
+	GstSample *sample = NULL;
+	GstElement *appsink = NULL;
+
+	gsize total_bytes = 0;
+	if (!stream || ch_idx >= MAX_IO_CHANNELS 
+		|| !g_atomic_int_get(&stream->pipeline_active))
+		goto error; 
+
+	GstState cur_state = GST_STATE_NULL, pending_state=GST_STATE_NULL;
+
+	GstMapInfo info;
+	gchar name[ELEMENT_NAME_SIZE];
+
+	// PER-CHANNEL lock (critical)
+	GRecMutex *ch_mutex = &stream->appsrc_mutexes[ch_idx];
+	g_rec_mutex_lock(ch_mutex);
+
+	if (session == NULL)
+		NAME_ELEMENT(name, "appsink", ch_idx);
+	else
+		NAME_SESSION_ELEMENT(name, "appsink", ch_idx, session);
+
+	// Double-check after acquiring channel mutex
+	if (!g_atomic_int_get(&stream->pipeline_active)) { 
+		goto exit;
+	}
+
+	appsink = gst_bin_get_by_name(GST_BIN(stream->pipeline), name); // threadsafe
+	if (!appsink) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to find %s in the pipeline\n", name);
+		goto exit;
+	}
+	gst_element_get_state(GST_ELEMENT(stream->pipeline), 
+		&cur_state, &pending_state, 0); 
+
+	if (cur_state != GST_STATE_PAUSED && cur_state != GST_STATE_PLAYING) {
+		goto exit;
+	}
+
+	if (gst_app_sink_is_eos(GST_APP_SINK(appsink))) { 
+		goto exit;
+	}
+
+	// Note: assumes leftover_bytes will never be more than buflen, which is
+	// likely true (packet is limited to MTU, while buflen is 8192)
+	// FIXME: revisit this to check whether we need this anymore
+
+	if (stream->leftover_bytes[ch_idx]) {
+		size_t copy = stream->leftover_bytes[ch_idx] <= needed_bytes ? stream->leftover_bytes[ch_idx] : needed_bytes;
+		memcpy(payload, stream->leftover[ch_idx], copy); // check
+		total_bytes += copy;
+		stream->leftover_bytes[ch_idx] -= copy;
+	}
+
+
+	while (total_bytes < needed_bytes) {
+		// switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "pulling buffer\n");
+		if (!g_atomic_int_get(&stream->pipeline_active)) {
+			goto exit;
+		}
+	
+		g_rec_mutex_unlock(ch_mutex);
+		sample = gst_app_sink_try_pull_sample(GST_APP_SINK(appsink),
+			10 * GST_MSECOND);	
+		g_rec_mutex_lock(ch_mutex);
+	
+		if (!sample) {
+			// switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Failed to pull sample\n");
+			g_rec_mutex_unlock(ch_mutex);
+			switch_cond_next();
+			g_rec_mutex_lock(ch_mutex);
+			break;
+		}
+
+		if (!g_atomic_int_get(&stream->pipeline_active)) {
+			DA_gst_sample_unref(sample); 
+			sample = NULL;
+			break;
+		}
+
+		AL_cnt_samples(sample);					// count the successful allocation
+		buf = gst_sample_get_buffer(sample);	 // no alloc no count
+												
+		if (!g_atomic_int_get(&stream->pipeline_active)) {
+			DA_gst_sample_unref(sample);
+			sample = NULL;
+			goto exit;
+		}
+
+		if (!buf) {
+			DA_gst_sample_unref(sample);
+			sample = NULL;
+			continue;
+		}
+
+		if (!g_atomic_int_get(&stream->pipeline_active)) {
+			DA_gst_sample_unref(sample);
+			sample = NULL;
+			goto exit;
+		}
+
+		gboolean r = gst_buffer_map(buf, &info, GST_MAP_READ);
+
+		if (r) {			
+			if (total_bytes + info.size > needed_bytes) {
+				gsize want = needed_bytes - total_bytes;
+				stream->leftover_bytes[ch_idx] = info.size - want;
+				memcpy(stream->leftover[ch_idx], info.data + want, stream->leftover_bytes[ch_idx]);
+				info.size = want;
+			}
+			memcpy(payload + total_bytes, info.data, info.size); // check
+			total_bytes += info.size;
+		}
+
+		gst_buffer_unmap(buf, &info); //check
+		DA_gst_sample_unref(sample);
+		sample = NULL;
+	}
 
 #if 0
   {
@@ -1227,69 +1654,106 @@ pull_buffers (g_stream_t * stream, unsigned char *payload, guint needed_bytes,
   }
 #endif
 
-  // switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "%u Returning needed %d, total_bytes: %d\n", ch_idx, needed_bytes, total_bytes);
-  // switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Leftover %lu\n", stream->leftover_bytes[ch_idx]);
+	// switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "%u Returning needed %d, total_bytes: %d\n", ch_idx,
+	// needed_bytes, total_bytes); switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Leftover %lu\n",
+	// stream->leftover_bytes[ch_idx]);
 
-out:
-  if (appsink !=NULL) gst_object_unref(GST_OBJECT(appsink));
-  if (buf!=NULL) gst_buffer_unref(buf);
-  if (sample != NULL) gst_sample_unref(sample);
-  return total_bytes;
+// fall thru
+
+exit:
+	if (appsink) {
+		gst_object_unref(appsink); 
+	}
+	DA_gst_sample_unref(sample);
+	g_rec_mutex_unlock(ch_mutex);
+error:
+	return (int) total_bytes;
 }
 
-
-void
-drop_input_buffers (gboolean drop, g_stream_t * stream, guint32 ch_idx)
+void drop_input_buffers(gboolean drop, g_stream_t *stream, guint32 ch_idx)
 {
-  gchar name[ELEMENT_NAME_SIZE];
-  GstElement *valve =NULL;
-  NAME_ELEMENT (name, "valve", ch_idx);
-  valve = gst_bin_get_by_name (GST_BIN (stream->pipeline), name);  //no mem allocation
-  if (valve == NULL) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to get valve element in the pipeline\n");
-    return;
-  }
-  g_object_set (valve, "drop", drop, NULL);
-  g_snprintf (name, STR_SIZE, "drop-ch%d-%d", ch_idx, drop);
-  dump_pipeline(stream->pipeline, name);
-  if (valve!=NULL) gst_object_unref(GST_OBJECT(valve));
+	GstElement *valve = NULL;
+	if (!stream || ch_idx >= MAX_IO_CHANNELS 
+		|| !g_atomic_int_get(&stream->pipeline_active)) { 
+		goto error; 
+	}
+
+	gchar name[ELEMENT_NAME_SIZE];
+
+	// PER-CHANNEL lock (critical)
+	GRecMutex *ch_mutex = &stream->appsrc_mutexes[ch_idx];
+	g_rec_mutex_lock(ch_mutex);
+	NAME_ELEMENT(name, "valve", ch_idx);
+
+	valve = AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), name); // increases ref count check 
+
+	if (!valve ) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to get valve element in the pipeline\n");
+		goto exit;
+	}
+
+	g_object_set(valve, "drop", drop, NULL);
+	g_snprintf(name, 2*STR_SIZE, "drop-ch%d-%d", ch_idx, drop);		//check increased string size
+
+	dump_pipeline(stream->pipeline, name);
+	//fall thru
+exit: 
+	DA_gst_object_unref(GST_OBJECT(valve));		//check 
+	g_rec_mutex_unlock(ch_mutex);
+error:
+	return;
 }
 
-gchar *
-get_rtp_stats (g_stream_t *stream) {
-
-  GstElement *rtpjitbuf=NULL;
-  gchar *stats_str = "";
-  rtpjitbuf = gst_bin_get_by_name(GST_BIN(stream->pipeline), "rx-jitbuf");
-
-  if (rtpjitbuf) {
-    GstStructure * stats;
-    g_object_get(G_OBJECT(rtpjitbuf), "stats", &stats, NULL);
-    stats_str = gst_structure_to_string (stats);
-	gst_structure_free(stats);	 // Fix: Added missing free
-	gst_object_unref(rtpjitbuf); // Fix: Added missing unref
-	return stats_str;
-  } else
-    return "";
-}
-
-void drop_output_buffers (gboolean drop, g_stream_t *stream)
+//caller must free returned string!!
+gchar *get_rtp_stats(g_stream_t *stream)
 {
-  GstElement *tx_valve=NULL;
-  gchar name[ELEMENT_NAME_SIZE];
+	GstElement *rtpjitbuf = NULL;
+	gchar *stats_str = NULL;		//fixed: dynamic allocation required since this is NOT on the stack
+	if (!g_atomic_int_get(&stream->pipeline_active)) { 
+		goto done_no_unlock; 
+	}
+	if (!stream) goto exit; //added check
 
-  tx_valve = gst_bin_get_by_name(GST_BIN(stream->pipeline), "tx-valve"); //no allocation
-  if (tx_valve == NULL) {
-    switch_log_printf (SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-        "Failed to get valve element in the pipeline\n");
-    return;
-  }
+	rtpjitbuf = AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), "rx-jitbuf");
 
-  g_object_set (tx_valve, "drop", drop, NULL);
+	if (rtpjitbuf) {
+		GstStructure *stats = NULL;
+		g_object_get(G_OBJECT(rtpjitbuf), "stats", &stats, NULL);
+		stats_str = gst_structure_to_string(stats);	
+		DA_gst_structure_free(stats); // added
 
-  g_snprintf (name, ELEMENT_NAME_SIZE, "tx-drop-%d", drop);
-  dump_pipeline(stream->pipeline, name);
+		stats = NULL;
+		DA_gst_object_unref(GST_OBJECT(rtpjitbuf));
+	} else {
+		stats_str = g_strdup_printf(""); // must be heap
+	}
+exit:
+done_no_unlock:
+	return stats_str;			//deallocated by caller!!
+}
 
-  if (tx_valve !=NULL) gst_object_unref(GST_OBJECT(tx_valve));
+void drop_output_buffers(gboolean drop, g_stream_t *stream)
+{
+	if (!g_atomic_int_get(&stream->pipeline_active)) { 
+		goto done_no_unlock; 
+	}
+	GstElement *tx_valve = NULL;
+	gchar name[ELEMENT_NAME_SIZE];
+	if (!stream) goto exit;
+
+	tx_valve = AL_gst_bin_get_by_name(GST_BIN(stream->pipeline), "tx-valve"); 
+	if (!tx_valve) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to get valve element in the pipeline\n");
+		goto exit;
+	}
+
+	g_object_set(tx_valve, "drop", drop, NULL);
+
+	g_snprintf(name, ELEMENT_NAME_SIZE, "tx-drop-%d", drop);
+	dump_pipeline(stream->pipeline, name);
+	//fall thru
+exit:
+	DA_gst_object_unref(GST_OBJECT(tx_valve));
+done_no_unlock:
+	return;
 }

--- a/src/mod/endpoints/mod_aes67/aes67_api.h
+++ b/src/mod/endpoints/mod_aes67/aes67_api.h
@@ -3,7 +3,7 @@
 
 #include <gst/gst.h>
 #include <switch.h>
-
+#define MOD_AES_VERSION_DATE "2026-02-01"
 #define DIRECTION_TX 1 << 0
 #define DIRECTION_RX 1 << 1
 
@@ -15,74 +15,96 @@
 #define TS_CONTEXT_NAME_LEN 100
 #define SESSION_ID_LEN 20
 
-typedef enum
-{ L16, L24 } aes67_codec_t;
+// necessary idle time (no unscheduled calling) before trim
+#define IDLE_THRESHOLD_SEC 60 
+// to reduce polling overhead
+#define IDLE_POLLING_SEC 5	 
+// how often to clear memory by default
+#define INTERVAL_MIN 8*60L
+// 60*24*31 == 31 days
+#define MAXMIN 44640
+// double-expansion for macros
+#define STR(s) #s
+#define XSTR(s) STR(s)
+
+typedef enum { L16, L24 } aes67_codec_t;
 
 typedef struct g_stream g_stream_t;
 
-typedef void event_callback_t (gchar * error_msg, g_stream_t * stream);
-typedef struct
-{
-  char rx_ip_addr[IP_ADDR_MAX_LEN];
-  int rx_port;
-  char tx_ip_addr[IP_ADDR_MAX_LEN];
-  int tx_port;
-  int direction;
-  int sample_rate;
-  char bit_depth[AUDIO_FMT_STR_LEN];
-  int channels;
-  aes67_codec_t tx_codec;
-  aes67_codec_t rx_codec;
-  int codec_ms;
-  char *name;
-  double ptime_ms;
-  GstClock *clock;
-  gint synthetic_ptp;
-  double rtp_ts_offset;
-  char *rtp_iface;
-  int rtp_payload_type;
-  int rtp_jitbuf_latency;
-  gboolean txdrop;
-  char *ts_context_name;
-  gboolean is_backup_sender;
-  int backup_sender_idle_wait_ms;
+typedef void event_callback_t(gchar *error_msg, g_stream_t *stream);
+typedef struct {
+	char rx_ip_addr[IP_ADDR_MAX_LEN];
+	int rx_port;
+	char tx_ip_addr[IP_ADDR_MAX_LEN];
+	int tx_port;
+	int direction;
+	int sample_rate;
+	char bit_depth[AUDIO_FMT_STR_LEN];
+	int channels;
+	aes67_codec_t tx_codec;
+	aes67_codec_t rx_codec;
+	int codec_ms;
+	char *name;
+	double ptime_ms;
+	GstClock *clock;
+	gint synthetic_ptp;
+	double rtp_ts_offset;
+	char *rtp_iface;
+	int rtp_payload_type;
+	int rtp_jitbuf_latency;
+	gboolean txdrop;
+	char *ts_context_name;
+	gboolean is_backup_sender;
+	int backup_sender_idle_wait_ms;
 } pipeline_data_t;
 
-struct g_stream
-{
-  GstPipeline *pipeline;
-  GMainLoop *mainloop;
-  GThread *thread;
-  unsigned char leftover[MAX_IO_CHANNELS][SWITCH_RECOMMENDED_BUFFER_SIZE];
-  size_t leftover_bytes[MAX_IO_CHANNELS];
-  event_callback_t *error_cb;
-  guint cb_rx_stats_id;
-  volatile gint clock_sync;
-  GstClock *clock;
-  gint sample_rate;
-  char *ts_ctx;
-  gboolean pause_backup_sender;
-  gboolean txdrop;
-  guint backup_sender_idle_timer;
-  int backup_sender_idle_wait_ms;
+
+struct g_stream {
+	GstPipeline *pipeline;
+	GMainLoop *mainloop;
+	GThread *thread;
+	unsigned char leftover[MAX_IO_CHANNELS][SWITCH_RECOMMENDED_BUFFER_SIZE];
+	size_t leftover_bytes[MAX_IO_CHANNELS];
+	event_callback_t *error_cb;
+	guint cb_rx_stats_id;
+	volatile gint clock_sync;
+	GstClock *clock;
+	gint sample_rate;
+	char *ts_ctx;
+	gboolean pause_backup_sender;
+	gboolean txdrop;
+	volatile gint backup_sender_idle_timer;
+	volatile gint pipeline_active; // 0 = stopping/stopped, 1 = active
+	int backup_sender_idle_wait_ms;
+	guint bus_watch_id;			   // added
+	gulong deinterleave_signal_id; // added
+	guint jitterbuf_signal_id;
+	GRecMutex appsrc_mutexes[MAX_IO_CHANNELS]; // One per channel added - self init
+	volatile gint pipeline_elements_count;	// Track elements added to pipeline
 };
 
-g_stream_t *create_pipeline (pipeline_data_t *data, event_callback_t * error_cb);
-void *start_pipeline (void *data);
-void stop_pipeline (g_stream_t * pipeline);
-void teardown_mainloop (GMainLoop * loop);
-void start_mainloop (GMainLoop * loop);
+g_stream_t *create_pipeline(pipeline_data_t *data, event_callback_t *error_cb);
+void *start_pipeline(void *data);
+void stop_pipeline(g_stream_t *pipeline);
+void teardown_mainloop(GMainLoop *loop);
+void start_mainloop(GMainLoop *loop);
 
-gboolean push_buffer (g_stream_t *stream, unsigned char *payload, guint len,
-    guint ch_idx, switch_timer_t * timer);
-int pull_buffers (g_stream_t * stream, unsigned char *payload, guint buflen,
-    guint ch_idx, switch_timer_t * timer, gchar *session);
-void drop_input_buffers (gboolean drop, g_stream_t * stream, guint32 ch_idx);
-gchar *get_rtp_stats (g_stream_t *stream);
-void drop_output_buffers (gboolean drop, g_stream_t * stream);
+gboolean push_buffer(g_stream_t *stream, unsigned char *payload, guint len, guint ch_idx, switch_timer_t *timer);
+int pull_buffers(g_stream_t *stream, unsigned char *payload, guint buflen, guint ch_idx, switch_timer_t *timer,
+				 gchar *session);
+void drop_input_buffers(gboolean drop, g_stream_t *stream, guint32 ch_idx);
+gchar *get_rtp_stats(g_stream_t *stream);
+void drop_output_buffers(gboolean drop, g_stream_t *stream);
 gboolean add_appsink(g_stream_t *stream, guint ch_idx, gchar *session);
 gboolean remove_appsink(g_stream_t *stream, guint ch_idx, gchar *session);
 void use_ptp_clock(g_stream_t *stream, GstClock *ptp_clock);
-void dump_pipeline (GstPipeline *pipe, const char *name);
+void dump_pipeline(GstPipeline *pipe, const char *name);
+void account_pipeline_children(g_stream_t *stream);
+void CompactHeaps(void);
+void TrimCurrentProcessWorkingSet(void);
+void periodic_mem_check(BOOL force);
+volatile extern BOOL memcheck_active;
+void heartbeat_callback(switch_event_t *event);
+extern long interval_min;
 
 #endif /*__GSTREAMER_API__*/

--- a/src/mod/endpoints/mod_aes67/aes67_counters.h
+++ b/src/mod/endpoints/mod_aes67/aes67_counters.h
@@ -1,0 +1,22 @@
+#ifndef _AES67COUNTERS
+#define _AES67COUNTERS
+typedef struct {
+    int bufs;
+	int chars;
+    int caps;
+    int objs;
+    int errs;
+    int structs;
+    int samples;
+    int memory;
+    int events;
+    int messages;
+    int features;
+    int gobjects;
+	int debugs;
+	int stats;
+} G_alloc_counts;
+
+// -- need to define the following in c file --
+extern volatile G_alloc_counts g_alloc_counts;	// declared volatile and accessed atomically to avoid miscounts due to threading
+#endif

--- a/src/mod/endpoints/mod_aes67/cpp.hint
+++ b/src/mod/endpoints/mod_aes67/cpp.hint
@@ -1,0 +1,4 @@
+// Hint files help the Visual Studio IDE interpret Visual C++ identifiers
+// such as names of functions and macros.
+// For more information see https://go.microsoft.com/fwlink/?linkid=865984
+#define MU_WRAPV2p(fname, tp1, p1, tp2, p2, l) inline void MUp_##fname(tp1 p1, tp2, p2) { switch_mutex_lock(l); fname(p1, p2); switch_mutex_unlock(l); }

--- a/src/mod/endpoints/mod_aes67/mod_aes67.vcxproj
+++ b/src/mod/endpoints/mod_aes67/mod_aes67.vcxproj
@@ -107,7 +107,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <CodeAnalysisRuleSet>NativeMinimumRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>false</RunCodeAnalysis>
-    <IncludePath>C:\freeswitch\libs\portaudio\src\os\win;$(IncludePath)</IncludePath>
+    <IncludePath>C:\gstreamer\1.0\msvc_x86_64\lib\glib-2.0\include\;C:\gstreamer\1.0\msvc_x86_64\include\glib-2.0\;C:\gstreamer\1.0\msvc_x86_64\include\;C:\gstreamer\1.0\msvc_x86_64\include\gstreamer-1.0;C:\gstreamer\1.0\msvc_x86_64\include\gstreamer-1.0\gst\app;C:\gstreamer\1.0\msvc_x86_64\include\gstreamer-1.0\gst\net;C:\gstreamer\1.0\msvc_x86_64\include\gstreamer-1.0\gst;C:\freeswitch\libs\portaudio\src\os\win;$(IncludePath)</IncludePath>
+    <ReferencePath>C:\gstreamer\1.0\msvc_x86_64\include\gstreamer-1.0\gst;C:\freeswitch\libs\portaudio\src\os\win;C:\gstreamer\1.0\msvc_x86_64\include\gstreamer-1.0\gst\app;C:\gstreamer\1.0\msvc_x86_64\include\gstreamer-1.0\gst\net;$(ReferencePath)</ReferencePath>
+    <SourcePath>C:\freeswitch\libs\portaudio\src\os\win;$(SourcePath)</SourcePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -180,20 +182,22 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>ksuser.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\..\libs\portaudio\winvc\Lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\..\libs\portaudio\winvc\Lib;%(AdditionalLibraryDirectories);C:\gstreamer\1.0\msvc_x86_64\lib</AdditionalLibraryDirectories>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
       <TargetMachine>MachineX64</TargetMachine>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="aes67_api.c" />
     <ClCompile Include="mod_aes67.c" />
+    <ClCompile Include="trim_mem.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="aes67_alloc.h" />
     <ClInclude Include="aes67_api.h" />
+    <ClInclude Include="aes67_counters.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\libs\win32\apr\libapr.2017.vcxproj">
@@ -204,6 +208,15 @@
       <Project>{202d7a4e-760d-4d0e-afa1-d7459ced30ff}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="x64\Release\mod_aes67.vcxproj.FileListAbsolute.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="cpp.hint" />
+    <None Include="Makefile.am" />
+    <None Include="README.md" />
+    <None Include="x64\Release\mod_aes67.dll.recipe" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/mod/endpoints/mod_aes67/trim_mem.c
+++ b/src/mod/endpoints/mod_aes67/trim_mem.c
@@ -1,0 +1,84 @@
+﻿#include "aes67_api.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <psapi.h> // For GetProcessHeaps if needed
+
+/*
+Optional memory cleansing - call be called programmatically from aes67 CLI
+or alternately from CLI script in Freeswitch 
+	"fsctl reclaim_mem"
+
+For heap-specific cleanup, enumerate private heaps with GetProcessHeaps and call HeapCompact(hHeap, 0) on each
+during idle periods; it coalesces free blocks but rarely shrinks the committed virtual address space and is mainly for
+convenience as Windows auto-compacts on HeapFree
+
+Call TrimWorkingSetIdle() periodically (e.g., every 30-60 seconds of idle) or on telephony idle detection; avoid during
+active RTP/audio processing to prevent latency spikes from page faults. ​
+
+Performance Considerations
+Working set trimming works best for telephony DLLs with bursty allocations, as it reduces RSS (resident set size) by up
+to 2/3 during idle without affecting virtual commit size.
+
+Monitor with GetProcessMemoryInfo before/after to tune
+frequency; excessive calls hurt perf. 
+HeapCompact adds minimal overhead but offers little footprint reduction unless fragmented. ​
+*/
+
+volatile BOOL memcheck_active = TRUE;			//default is on
+
+void CompactHeaps(void)
+{
+	HANDLE hHeap = GetProcessHeap();
+	HeapCompact(hHeap, 0);
+
+	// For private heaps: enumerate and compact each
+	DWORD numHeaps;
+	HANDLE *heaps = NULL;
+	if (GetProcessHeaps(0, heaps) == 0) { // First pass for count
+		numHeaps = GetProcessHeaps(0, NULL);
+		heaps = HeapAlloc(GetProcessHeap(), 0, numHeaps * sizeof(HANDLE));
+		GetProcessHeaps(numHeaps, heaps);
+		for (DWORD i = 0; i < numHeaps; ++i) { HeapCompact(heaps[i], 0); }
+		HeapFree(GetProcessHeap(), 0, heaps);
+	}
+}
+
+/*
+Windows treats both parameters as special when set to(SIZE_T)− 1(SIZE_T)−1
+	: it attempts to remove as many pages as possible from the process working set,
+	  effectively “emptying” it without changing virtual allocations
+		  or destroying heap contents
+				 .This is equivalent to calling EmptyWorkingSet on the process and is safe to trigger during genuine
+			 idle periods to reduce resident memory pressure.
+*/
+
+void TrimCurrentProcessWorkingSet(void)
+{
+	HANDLE hProcess = GetCurrentProcess();
+
+	// Optional: ensure the call succeeds; you might log or collect stats.
+	if (!SetProcessWorkingSetSize(hProcess, (SIZE_T)-1, (SIZE_T)-1)) {
+		// handle error if desired: GetLastError();
+	}
+}
+#else
+void CompactHeaps(void) { ; }
+void TrimCurrentProcessWorkingSet(void) { ; }
+#endif
+
+
+long interval_min = INTERVAL_MIN;
+
+// FreeSwitch calls this every 20 seconds by default -set in config files as an XML parameter, if not set it is 20secs
+void heartbeat_callback(switch_event_t *event)
+{
+	static long unsigned call_count = 0;
+	call_count++;
+	if (call_count >=
+		((3600L / 20L) * interval_min) / 60L) { // convert to number of 20 sec blips - careful about integer division
+		call_count = 0;
+		periodic_mem_check(TRUE); // force clear
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "AES67: Cleaning memory ---\n");
+	}
+}


### PR DESCRIPTION
- stop_pipeline, push and pull buffer per-channel-mutexes added as well as atomic flags to wait for streams to end
- load-tested for weeks with 50+ calls a minute, to a total of 80 calls on peak, audio passes well under load
- memory remains stable and rises and falls with call volume as expected
- all error paths fully dereference gstreamer ptrs
- gstreamer reference counters added for debugging
- new aes67 commands added (WIN32 only):
-- aes67 version                                              // displays version date
-- aes67 autocleanmem <on|off>                  // displays autoclean status or turns periodic auto mem cleaning on or off
-- aes67 autocleanmem setmin [1-44640]  // turns on and sets autoclean interval in minutes (up to 31 days)
-- aes67 clrwrkset                                          // clears unused working set memory, no calla are dropped                  
-- aes67 compactheap                                  // optional heap consolidation, does not drop calls   
-- aes67 memcleancount                              // displays total call count for the above 2 functions 
